### PR TITLE
Add README and npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Matrix Tool
+
+This project consists of a FastAPI backend and a Vite/React frontend.
+
+## Installation
+
+1. **Backend dependencies**
+   ```bash
+   python -m pip install -r backend/requirements.txt
+   ```
+2. **Frontend dependencies**
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+## Running the application
+
+### Backend
+
+Start the FastAPI backend using uvicorn:
+```bash
+uvicorn backend.main:app --reload
+```
+
+### Frontend
+
+Run the Vite development server:
+```bash
+cd frontend
+npm run dev
+```
+
+## Linting and type checking (offline)
+
+After the frontend dependencies have been installed once, the following commands
+can be executed without additional downloads:
+
+```bash
+npm run lint       # runs eslint on the frontend source
+npm run typecheck  # runs TypeScript type checking
+```
+
+Currently this repository does not contain automated tests.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,11 @@
 {
   "dependencies": {
     "react-router-dom": "^7.6.2"
+  },
+  "scripts": {
+    "start:backend": "uvicorn backend.main:app --reload",
+    "start:frontend": "npm --prefix frontend run dev",
+    "lint": "npm --prefix frontend run lint",
+    "typecheck": "npm --prefix frontend run typecheck"
   }
 }


### PR DESCRIPTION
## Summary
- document how to install dependencies and run the app
- add npm scripts for starting, linting and type-checking
- provide a simple script for type checking in the frontend

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852a90b65d48320a37a31d5df58ed1a