### PR TITLE
Add default path properties and improve ranking error handling

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -49,6 +49,16 @@ class Config:
         return self.config["Dateien"]["default_kombi"]
 
     @property
+    def current_ideen_path(self):
+        """Vollständiger Pfad zur aktuell ausgewählten Ideensammlung."""
+        return Path(self.selectionideas_dir) / self.default_ideen
+
+    @property
+    def current_kombi_path(self):
+        """Vollständiger Pfad zur aktuell ausgewählten Kombisammlung."""
+        return Path(self.selectioncombis_dir) / self.default_kombi
+
+    @property
     def ideen_template_path(self):
         return self.config["Dateien"]["ideentemplate"]
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -200,8 +200,12 @@ async def read_uploaded_file(sammlung_typ: str, session: str, filename: str, lan
 # ---- Beispiel: Ranking-Endpoint (optional, je nach App-Logik) ----
 @app.get("/api/ranking")
 async def get_ranking(lang: str = Query(default=config.default_language)):
+    ideen_path = Path(config.current_ideen_path)
+    if not ideen_path.exists():
+        return JSONResponse(status_code=404, content={"error": t("file_not_found", lang)})
+
     try:
-        loader = ExcelLoader(config.current_ideen_path, sprache=lang)
+        loader = ExcelLoader(ideen_path, sprache=lang)
         df = loader.lade_excel()
         ideen = df[["titel", "beschreibung"]].fillna("").to_dict(orient="records")
         return {


### PR DESCRIPTION
## Summary
- compute full paths for default idea and combi selections
- use these paths in the ranking endpoint and check for missing files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495185fad083209061a5161630c6a8