### PR TITLE
Fix upload error message handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -137,12 +137,13 @@ const handleKombiUpload = async (file: File, sessionId: string) => {
       setStatusToastMessage(t("uploadSuccess") + ": " + result.filename);
       setStatusToastType("success");
     } else {
-      setStatusToastMessage(t("uploadError") + ": " + t(result.error));
+      const errMsg = result.error ?? "unknown error";
+      setStatusToastMessage(t("uploadError") + ": " + t(errMsg));
       setStatusToastType("error");
     }
   } catch (error) {
     console.error("Fehler beim Hochladen:", error);
-    setStatusToastMessage(t("uploadError") + ": " + t(result.error));
+    setStatusToastMessage(t("uploadError"));
     setStatusToastType("error");
   } finally {
     setStatusToastOpen(true);
@@ -197,13 +198,14 @@ const handleKombiSammlungChange = (dateiName: string) => {
       setStatusToastMessage(t("uploadSuccess") + ": " + result.filename);
       setStatusToastType("success");
     } else {
-      setStatusToastMessage(t("uploadError") + ": " + (error instanceof Error ? error.message : String(error)));
+      const errMsg = result.error ?? "unknown error";
+      setStatusToastMessage(t("uploadError") + ": " + t(errMsg));
 
       setStatusToastType("error");
     }
   } catch (error) {
     console.error("Fehler beim Hochladen:", error);
-    setStatusToastMessage(t("uploadError") + ": " + (error instanceof Error ? error.message : String(error)));
+    setStatusToastMessage(t("uploadError"));
 
     setStatusToastType("error");
   } finally {


### PR DESCRIPTION
## Summary
- avoid using scoped variables outside of their blocks in handleKombiUpload
- avoid using scoped variables outside of their blocks in handleIdeenUpload
- ensure catch block shows generic error

## Testing
- `npm --prefix frontend run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852baa62ce08320aee4171b072ec853