### PR TITLE
Add statistic modal trigger

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -238,6 +238,10 @@ const handleKombiSammlungChange = (dateiName: string) => {
     setSaveRunId(undefined);
   };
 
+  const openStatistikForm = () => {
+    setStatistikFormOpen(true);
+  };
+
   const handleCloseStatistikForm = () => {
     setStatistikFormOpen(false);
   };
@@ -310,6 +314,7 @@ const handleKombiSammlungChange = (dateiName: string) => {
                 onIdeenUpdate={handleIdeenUpdate}
                 onBewertungsOptionenChange={handleBewertungsOptionenChange}
                 onGewichtungenUpdate={handleGewichtungenUpdate}
+                onOpenStatistikForm={openStatistikForm}
               />
             </div>
           )}

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -15,6 +15,7 @@ interface Props {
   onIdeenUpdate: (ideen: any[]) => void;
   onBewertungsOptionenChange: (field: string, value: any) => void;
   onGewichtungenUpdate: (g: any[]) => void;
+  onOpenStatistikForm?: () => void;
 }
 
 export const ConfigPage = ({
@@ -28,6 +29,7 @@ export const ConfigPage = ({
   onIdeenUpdate,
   onBewertungsOptionenChange,
   onGewichtungenUpdate,
+  onOpenStatistikForm = () => {},
 }: Props) => {
   return (
     <div>
@@ -43,7 +45,11 @@ export const ConfigPage = ({
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       <div className="mt-6 text-center">
-        <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+        <Link
+          to="/results"
+          onClick={onOpenStatistikForm}
+          className="px-4 py-2 bg-[#1d2c5b] text-white rounded"
+        >
           Weiter
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- allow ConfigPage to notify App to open statistics form
- trigger statistics dialog when leaving config page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852baa574888320957600ff3c58be4b