### PR TITLE
Change default language to English

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,9 @@ function App() {
 	
 	const sessionId = getSessionId();
   const { t, i18n } = useTranslation();
-  const [language, setLanguage] = useState(i18n.language || "de");
+  const [language, setLanguage] = useState(
+    i18n.language || (import.meta.env.VITE_DEFAULT_LANGUAGE || "en"),
+  );
 
  
   const [ideen, setIdeen] = useState<any[]>([]);

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -2,9 +2,11 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
+const defaultLanguage = import.meta.env.VITE_DEFAULT_LANGUAGE || "en";
+
 i18n.use(initReactI18next).init({
-  lng: "de", // Standard-Sprache: Deutsch
-  fallbackLng: "de",
+  lng: defaultLanguage,
+  fallbackLng: defaultLanguage,
   debug: true,
   interpolation: {
     escapeValue: false,


### PR DESCRIPTION
## Summary
- default i18n language is now English
- respect `VITE_DEFAULT_LANGUAGE` for the starting language

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6852baa120048320bb08e0d66e4ec902