### PR TITLE
Implement page skeleton and i18n restructure

### DIFF
--- a/DOKUMENTATION.md
+++ b/DOKUMENTATION.md
@@ -38,21 +38,17 @@ Deshalb wird dieses Projekt **schrittweise** aufgebaut und der Quellcode immer d
 
 ## 🛠 Nächste Aufgaben
 
-### 🔜 Schritt 2: Backend-Grundgerüst erstellen
-- Ordner `backend/` anlegen
-- FastAPI-Projekt mit `main.py`
-- Routen:
-  - `/api/konfiguration` → lädt `matrixconfig.ini`
-  - `/api/vorlage/ideen` → lädt leeres Template
-  - `/api/vorlage/kombis` → lädt leeres Template
-  - `/api/upload/ideen` → lädt Nutzerdatei hoch
-  - `/api/upload/kombis` → lädt Nutzerdatei hoch
-- Dummy-Daten in `AktuelleSammlung/`
+### Aktueller Stand (Juni 2025)
+Die Grundfunktionen von Backend und Frontend sind lauffähig.
+Neu hinzugekommen sind:
+- Aufsplittung der Sprachdatei in `src/i18n/` mit einem zentralen `index.ts`.
+- Erste Aufteilung des Frontends in mehrere Seiten (`SelectDataPage`, `IdeaSelectionPage`, `CombinationSelectionPage`, `PersonalDataPage`, `ConfigSummaryPage`, `CalcResultsPage`).
+- Navigation zwischen den Seiten über "Weiter"/"Zurück" Buttons.
 
-### 🔜 Schritt 3: Frontend-Grundstruktur (React)
-- Auswahlfelder für aktuelle / eigene Sammlung
-- Multiple-Choice-Matrix zur Gewichtung
-- Platzhalter-Logik für Berechnung + Ranking
+### Nächste Schritte
+- Inhalte der neuen Seiten weiter ausbauen (Beschreibungstexte, Validierung).
+- Altes Routing aufräumen und ungenutzte Komponenten entfernen.
+- Statistik-Formular an geeigneter Stelle einbinden und speichern.
 
 ---
 
@@ -78,4 +74,4 @@ Dann kannst du sofort am nächsten Schritt weiterarbeiten.
 
 ---
 
-*Letzte Aktualisierung durch ChatGPT: (28.05.2025:13:07)*
+*Letzte Aktualisierung durch ChatGPT: (18.06.2025:13:24)*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,9 +9,12 @@ import { useTranslation } from "react-i18next";
 import { Routes, Route } from "react-router-dom";
 
 import { StartPage } from "./pages/StartPage";
-import { UploadPage } from "./pages/UploadPage";
-import { ConfigPage } from "./pages/ConfigPage";
-import { ResultsPage } from "./pages/ResultsPage";
+import { SelectDataPage } from "./pages/SelectDataPage";
+import { IdeaSelectionPage } from "./pages/IdeaSelectionPage";
+import { CombinationSelectionPage } from "./pages/CombinationSelectionPage";
+import { PersonalDataPage } from "./pages/PersonalDataPage";
+import { ConfigSummaryPage } from "./pages/ConfigSummaryPage";
+import { CalcResultsPage } from "./pages/CalcResultsPage";
 
 // import { KombiInfoModal } from "./components/KombiInfoModal"; // ← entfernt, da ungenutzt
 import { SaveRunSuccess } from "./components/SaveRunSuccess";
@@ -289,10 +292,10 @@ const handleKombiSammlungChange = (dateiName: string) => {
       <Routes>
         <Route path="/" element={<StartPage />} />
         <Route
-          path="/upload"
+          path="/select-data"
           element={(
             <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
-              <UploadPage
+              <SelectDataPage
                 aktuelleIdeensammlung={aktuelleIdeensammlung}
                 aktuelleKombiSammlung={aktuelleKombiSammlung}
                 onIdeenSammlungChange={handleIdeenSammlungChange}
@@ -304,21 +307,50 @@ const handleKombiSammlungChange = (dateiName: string) => {
           )}
         />
         <Route
-          path="/config"
+          path="/ideas"
           element={(
             <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
-              <ConfigPage
+              <IdeaSelectionPage
                 ideen={ideen}
                 sprache={language as "de" | "en" | "fr"}
+                onIdeenUpdate={handleIdeenUpdate}
+              />
+            </div>
+          )}
+        />
+        <Route
+          path="/combinations"
+          element={(
+            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+              <CombinationSelectionPage
+                gewichtungen={gewichtungen}
                 runde1={runde1}
                 runde2={runde2}
                 appTester={appTester}
                 datenfreigabe={datenfreigabe}
-                gewichtungen={gewichtungen}
-                onIdeenUpdate={handleIdeenUpdate}
-                onBewertungsOptionenChange={handleBewertungsOptionenChange}
                 onGewichtungenUpdate={handleGewichtungenUpdate}
-                onOpenStatistikForm={openStatistikForm}
+                onOptionsChange={handleBewertungsOptionenChange}
+              />
+            </div>
+          )}
+        />
+        <Route
+          path="/personal"
+          element={(
+            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+              <PersonalDataPage onOpenStatistikForm={openStatistikForm} />
+            </div>
+          )}
+        />
+        <Route
+          path="/summary"
+          element={(
+            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+              <ConfigSummaryPage
+                ideenCount={ideen.length}
+                activeIdeen={ideen.filter((i) => i.aktiv).length}
+                kombiCount={gewichtungen.length}
+                activeKombis={gewichtungen.filter((k) => k.aktiv).length}
               />
             </div>
           )}
@@ -327,7 +359,7 @@ const handleKombiSammlungChange = (dateiName: string) => {
           path="/results"
           element={(
             <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
-              <ResultsPage rankingEintraege={rankingEintraege} />
+              <CalcResultsPage rankingEintraege={rankingEintraege} />
             </div>
           )}
         />

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -1,17 +1,4 @@
-// src/i18n.ts
-import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
-
-const defaultLanguage = import.meta.env.VITE_DEFAULT_LANGUAGE || "en";
-
-i18n.use(initReactI18next).init({
-  lng: defaultLanguage,
-  fallbackLng: defaultLanguage,
-  debug: true,
-  interpolation: {
-    escapeValue: false,
-  },
-  resources: {
+const common = {
     de: {
       translation: {
         title: "Matrix Bewertungstool",
@@ -21,6 +8,8 @@ i18n.use(initReactI18next).init({
         downloadTemplate: "Vorlage herunterladen",
         start: "Start",
         next: "Weiter",
+        back: "Zurück",
+        reset: "Zurücksetzen",
         calculate: "Berechnen",
         score: "Score",
         info: "Info",
@@ -51,6 +40,7 @@ i18n.use(initReactI18next).init({
         currentCombinationCollection: "Aktuelle Kombinationssammlung",
         uploadErrorInvalidFile: "Bitte laden Sie eine Excel-Datei (.xlsx) hoch.",
         exportRankingCSV: "Ranking als CSV exportieren",
+        summary: "Zusammenfassung",
 
         noIdeasLoaded: "Keine Ideen geladen.",
         noDescription: "Keine Beschreibung",
@@ -114,6 +104,8 @@ i18n.use(initReactI18next).init({
         downloadTemplate: "Download template",
         start: "Start",
         next: "Next",
+        back: "Back",
+        reset: "Reset",
         calculate: "Calculate",
         score: "Score",
         info: "Info",
@@ -144,6 +136,7 @@ i18n.use(initReactI18next).init({
         currentCombinationCollection: "Current combination collection",
         uploadErrorInvalidFile: "Please upload an Excel file (.xlsx).",
         exportRankingCSV: "Export ranking as CSV",
+        summary: "Summary",
 
         noIdeasLoaded: "No ideas loaded.",
         noDescription: "No description",
@@ -207,6 +200,8 @@ i18n.use(initReactI18next).init({
         downloadTemplate: "Téléchargez le modèle",
         start: "Démarrer",
         next: "Suivant",
+        back: "Retour",
+        reset: "Réinitialiser",
         calculate: "Calculez",
         score: "Score",
         info: "Info",
@@ -237,6 +232,7 @@ i18n.use(initReactI18next).init({
         currentCombinationCollection: "Collection de combinaisons actuelle",
         uploadErrorInvalidFile: "Veuillez téléverser un fichier Excel (.xlsx).",
         exportRankingCSV: "Exporter le classement en CSV",
+        summary: "Résumé",
 
         noIdeasLoaded: "Aucune idée chargée.",
         noDescription: "Pas de description",
@@ -293,7 +289,5 @@ i18n.use(initReactI18next).init({
         uploadSuccess: "Téléversement réussi",
       },
     },
-  },
-});
-
-export default i18n;
+};
+export default common;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,21 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import common from "./common";
+
+const defaultLanguage = import.meta.env.VITE_DEFAULT_LANGUAGE || "en";
+
+const resources = {
+  de: { translation: { ...common.de.translation } },
+  en: { translation: { ...common.en.translation } },
+  fr: { translation: { ...common.fr.translation } },
+};
+
+i18n.use(initReactI18next).init({
+  lng: defaultLanguage,
+  fallbackLng: defaultLanguage,
+  debug: true,
+  interpolation: { escapeValue: false },
+  resources,
+});
+
+export default i18n;

--- a/frontend/src/pages/CalcResultsPage.tsx
+++ b/frontend/src/pages/CalcResultsPage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Ranking } from '../components/Ranking';
+import { ExportRankingButton } from '../components/ExportRankingButton';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  rankingEintraege: any[];
+}
+
+export const CalcResultsPage = ({ rankingEintraege }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <Ranking eintraege={rankingEintraege} />
+      <div className="mt-6 flex justify-between items-center gap-4">
+        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          {t('reset')}
+        </Link>
+        <ExportRankingButton eintraege={rankingEintraege} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { WeightingSelector } from '../components/WeightingSelector';
+import { BewertungsOptionen } from '../components/BewertungsOptionen';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  gewichtungen: any[];
+  runde1: boolean;
+  runde2: boolean;
+  appTester: boolean;
+  datenfreigabe: 'offen' | 'anonym' | 'keine';
+  onGewichtungenUpdate: (g: any[]) => void;
+  onOptionsChange: (field: string, value: any) => void;
+}
+
+export const CombinationSelectionPage = ({
+  gewichtungen,
+  runde1,
+  runde2,
+  appTester,
+  datenfreigabe,
+  onGewichtungenUpdate,
+  onOptionsChange,
+}: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
+      <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
+        <BewertungsOptionen
+          runde1={runde1}
+          runde2={runde2}
+          appTester={appTester}
+          datenfreigabe={datenfreigabe}
+          onChange={onOptionsChange}
+        />
+      </div>
+      <div className="mt-6 flex justify-between">
+        <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">{t('back')}</Link>
+        <Link to="/personal" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">{t('next')}</Link>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  ideenCount: number;
+  activeIdeen: number;
+  kombiCount: number;
+  activeKombis: number;
+}
+
+export const ConfigSummaryPage = ({
+  ideenCount,
+  activeIdeen,
+  kombiCount,
+  activeKombis,
+}: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">{t('summary')}</h2>
+      <ul className="mb-4 list-disc list-inside">
+        <li>
+          {t('currentIdeaCollection')}: {activeIdeen} / {ideenCount}
+        </li>
+        <li>
+          {t('currentCombinationCollection')}: {activeKombis} / {kombiCount}
+        </li>
+      </ul>
+      <div className="mt-6 flex justify-between">
+        <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
+          {t('back')}
+        </Link>
+        <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+          {t('calculate')}
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { IdeenSelector } from '../components/IdeenSelector';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  ideen: any[];
+  sprache: 'de' | 'en' | 'fr';
+  onIdeenUpdate: (ideen: any[]) => void;
+}
+
+export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
+      <div className="mt-6 flex justify-between">
+        <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
+          {t('back')}
+        </Link>
+        <Link to="/combinations" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+          {t('next')}
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  onOpenStatistikForm: () => void;
+}
+
+export const PersonalDataPage = ({ onOpenStatistikForm }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div className="text-center">
+      <button
+        onClick={onOpenStatistikForm}
+        className="px-4 py-2 bg-gray-200 rounded mb-4"
+      >
+        {t('optionDataReleaseOpen')}
+      </button>
+      <div className="mt-6 flex justify-between">
+        <Link to="/combinations" className="px-4 py-2 bg-gray-300 rounded">
+          {t('back')}
+        </Link>
+        <Link to="/summary" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+          {t('next')}
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { CollectionSelectorIdeas } from '../components/CollectionSelectorIdeas';
+import { CollectionSelectorKombis } from '../components/CollectionSelectorKombis';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  aktuelleIdeensammlung: string;
+  aktuelleKombiSammlung: string;
+  onIdeenSammlungChange: (name: string) => void;
+  onKombiSammlungChange: (name: string) => void;
+  onIdeenUpload: (file: File) => void;
+  onKombiUpload: (file: File) => void;
+}
+
+export const SelectDataPage = ({
+  aktuelleIdeensammlung,
+  aktuelleKombiSammlung,
+  onIdeenSammlungChange,
+  onKombiSammlungChange,
+  onIdeenUpload,
+  onKombiUpload,
+}: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <CollectionSelectorIdeas
+        aktuelleSammlungName={aktuelleIdeensammlung}
+        onSammlungChange={onIdeenSammlungChange}
+        onUpload={onIdeenUpload}
+      />
+      <CollectionSelectorKombis
+        aktuelleSammlungName={aktuelleKombiSammlung}
+        onSammlungChange={onKombiSammlungChange}
+        onUpload={onKombiUpload}
+      />
+      <div className="mt-6 flex justify-between">
+        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          {t('back')}
+        </Link>
+        <Link to="/ideas" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+          {t('next')}
+        </Link>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- refactor i18n into `src/i18n` folder with index file
- add navigation texts for Back and Reset
- add initial pages for multi step flow
- update router to use new pages
- document the new structure in `DOKUMENTATION.md`

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852b95528b883209bdf13b32e759588