### PR TITLE
Make i18n debug optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ cd frontend
 npm run dev
 ```
 
+The i18next library's debug output is disabled by default. You can enable it by
+setting the `VITE_I18N_DEBUG` environment variable to `true` before starting the
+frontend:
+
+```bash
+VITE_I18N_DEBUG=true npm run dev
+```
+
 ## Linting and type checking (offline)
 
 After the frontend dependencies have been installed once, the following commands

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -3,6 +3,7 @@ import { initReactI18next } from "react-i18next";
 import common from "./common";
 
 const defaultLanguage = import.meta.env.VITE_DEFAULT_LANGUAGE || "en";
+const debugMode = import.meta.env.VITE_I18N_DEBUG === "true";
 
 const resources = {
   de: { translation: { ...common.de.translation } },
@@ -13,7 +14,7 @@ const resources = {
 i18n.use(initReactI18next).init({
   lng: defaultLanguage,
   fallbackLng: defaultLanguage,
-  debug: true,
+  debug: debugMode,
   interpolation: { escapeValue: false },
   resources,
 });


### PR DESCRIPTION
## Summary
- make i18n debugging controlled by `VITE_I18N_DEBUG`
- document i18n debugging in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852c1e37744832088269f4b1f9e8163