### PR TITLE
Improve page layout and reset navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -271,8 +271,7 @@ const handleKombiSammlungChange = (dateiName: string) => {
 
   return (
     <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center py-10">
-      <div className="w-full max-w-7xl bg-gray-800 text-white shadow-xl rounded-2xl p-8 relative">
-        <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-white/90 px-3 py-2 rounded-xl shadow border">
+      <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-white/90 px-3 py-2 rounded-xl shadow border">
 
           <label htmlFor="lang-select" className="font-semibold text-sm">{t("language")}</label>
           <select
@@ -287,7 +286,6 @@ const handleKombiSammlungChange = (dateiName: string) => {
             <option value="fr">Français</option>
           </select>
         </div>
-      </div>
 
       <Routes>
         <Route path="/" element={<StartPage />} />
@@ -338,7 +336,10 @@ const handleKombiSammlungChange = (dateiName: string) => {
           path="/personal"
           element={(
             <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
-              <PersonalDataPage onOpenStatistikForm={openStatistikForm} />
+              <PersonalDataPage
+                onOpenStatistikForm={openStatistikForm}
+                onCloseStatistikForm={handleCloseStatistikForm}
+              />
             </div>
           )}
         />

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -37,8 +37,17 @@ export const CombinationSelectionPage = ({
         />
       </div>
       <div className="mt-6 flex justify-between">
-        <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">{t('back')}</Link>
-        <Link to="/personal" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">{t('next')}</Link>
+        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          {t('reset')}
+        </Link>
+        <div className="flex gap-4">
+          <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/personal" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -28,12 +28,17 @@ export const ConfigSummaryPage = ({
         </li>
       </ul>
       <div className="mt-6 flex justify-between">
-        <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
+        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          {t('reset')}
         </Link>
-        <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('calculate')}
-        </Link>
+        <div className="flex gap-4">
+          <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+            {t('calculate')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -15,12 +15,17 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
     <div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
       <div className="mt-6 flex justify-between">
-        <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
+        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          {t('reset')}
         </Link>
-        <Link to="/combinations" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-        </Link>
+        <div className="flex gap-4">
+          <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/combinations" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
   onOpenStatistikForm: () => void;
+  onCloseStatistikForm: () => void;
 }
 
-export const PersonalDataPage = ({ onOpenStatistikForm }: Props) => {
+export const PersonalDataPage = ({
+  onOpenStatistikForm,
+  onCloseStatistikForm,
+}: Props) => {
   const { t } = useTranslation();
+  useEffect(() => {
+    onOpenStatistikForm();
+    return onCloseStatistikForm;
+  }, [onOpenStatistikForm, onCloseStatistikForm]);
   return (
     <div className="text-center">
       <button
@@ -17,12 +25,17 @@ export const PersonalDataPage = ({ onOpenStatistikForm }: Props) => {
         {t('optionDataReleaseOpen')}
       </button>
       <div className="mt-6 flex justify-between">
-        <Link to="/combinations" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
+        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          {t('reset')}
         </Link>
-        <Link to="/summary" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-        </Link>
+        <div className="flex gap-4">
+          <Link to="/combinations" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/summary" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -36,11 +36,16 @@ export const SelectDataPage = ({
       />
       <div className="mt-6 flex justify-between">
         <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
+          {t('reset')}
         </Link>
-        <Link to="/ideas" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-        </Link>
+        <div className="flex gap-4">
+          <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/ideas" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- center all pages and show reset button across steps
- auto-open personal data dialog when the page loads
- remove unused header wrapper

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852c1d4c30c832080f4b837c23de72b