### PR TITLE
Fix typo in matrixconfig.ini comment

### DIFF
--- a/backend/matrixconfig.ini
+++ b/backend/matrixconfig.ini
@@ -7,7 +7,7 @@ selectioncombis_dir = uploads/selectioncombis
 default_ideen = standard_ideen.xlsx
 default_kombi = default_kombi.xlsx
 
-# Pfade zu den Downlaod-Templates
+# Pfade zu den Download-Templates
 ideentemplate = ideen_template.xlsx
 kombitemplate = kombis_template.xlsx
 templatedir = templates


### PR DESCRIPTION
## Summary
- fix small spelling error in backend/matrixconfig.ini

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852c8e7e790832083075e76251de3d4