### PR TITLE
Improve layout and validation

### DIFF
--- a/ARCHITEKTUR.md
+++ b/ARCHITEKTUR.md
@@ -14,20 +14,29 @@ Durch Kombination von Attributen (aus einer Excel-Tabelle) sollen vergleichbare 
 ## 📁 Projektstruktur
 
 /backend/
-server.py ← Haupt-API: Upload, Bewertung, Statistik, Session
-excel_loader.py ← Einlesen & Validieren von Excel-Dateien (mehrsprachig, IDs)
-config_loader.py ← Einlesen Konfigurationsdateien (matrixconfig etc.)
-bewertung.py ← Bewertungslogik: Kombinationen, Gewichtungen, Richtung
-save_run.py ← (Blueprint) Speichern der Bewertungsläufe/Statistiken
+main.py ← Haupt-API für Upload, Bewertung, Statistik und Session
+loader/excel_loader.py ← Einlesen & Validieren von Excel-Dateien
+config_loader.py ← Laden der Konfiguration (`matrixconfig.ini`)
+bewertung.py ← Bewertungslogik für Kombinationen und Gewichtungen
+api/ ← Routen (z. B. `/save_run`)
 
-/frontend/
+/frontend/src/
 components/
-IdeenSelector.tsx ← Anzeige und Auswahl der Ideen, Attribut-Details, Mehrsprachigkeit
-CollectionSelector.tsx ← Dropdown & Upload für Ideensammlungen / Kombis
+IdeenSelector.tsx ← Anzeige und Auswahl der Ideen
+CollectionSelectorIdeas.tsx / CollectionSelectorKombis.tsx ← Dropdown & Upload
 WeightingSelector.tsx ← Gewichtung der Kombinationen
-BewertungsOptionen.tsx ← Optionen, z. B. Runden-Auswahl, Aktivieren/Deaktivieren
-Ranking.tsx ← (noch offen) Ranking- und Ergebnisanzeige
-StatistikForm.tsx ← (offen) Formular für Demografie/Statistikdaten
+BewertungsOptionen.tsx ← Optionen wie Runden-Auswahl
+Ranking.tsx ← Ranking- und Ergebnisanzeige
+StatistikForm.tsx ← Formular für Demografie/Statistikdaten
+StatusToast.tsx / SaveRunSuccess.tsx ← Rückmeldungen
+pages/
+StartPage.tsx, SelectDataPage.tsx,
+IdeaSelectionPage.tsx, CombinationSelectionPage.tsx,
+PersonalDataPage.tsx, ConfigSummaryPage.tsx,
+CalcResultsPage.tsx ← Einzelseiten der App
+i18n/
+index.ts ← Initialisiert die Übersetzungen
+common.ts ← Sprachdateien (de/en/fr)
 
 /templates/
 ideen_template.xlsx ← Vorlage für Ideensammlung (IDs, Sprachen, Attribute)
@@ -46,16 +55,22 @@ README_DE.md/README_EN.md ← Kurzbeschreibung, Nutzungshinweise, ToDo-Liste
 
 ## **2. Ablauf & Datenfluss**
 
-1. **Upload**
-   - Nutzer wählt aktuelle oder eigene Ideensammlung/Kombisammlung aus (Excel, Templates).
-   - Uploads werden **in der Session** zwischengespeichert (Dropdown-Auswahl) UND, wenn **kein Tester-Modus** aktiv, persistent im `storage`-Ordner mit UUID gespeichert.
+1. **Start & Datenauswahl**
+   - Die `StartPage` leitet auf die `SelectDataPage` weiter.
+   - Dort wählt der Nutzer Ideensammlung und Kombinationssammlung oder lädt eigene Excel-Dateien hoch. Uploads bleiben zunächst in der Session und werden – sofern kein App-Tester-Modus aktiv ist – im Ordner `storage` gespeichert.
 
-2. **Konfiguration & Bewertung**
-   - User gewichtet Kombinationen, aktiviert/deaktiviert Attribute, wählt Sprache etc.
-   - Bewertungslogik (`bewertung.py`) liest Excel, wertet Formeln aus, berechnet Scores, berücksichtigt Richtung (high/low).
+2. **Ideen und Kombinationen festlegen**
+   - In der `IdeaSelectionPage` werden Ideen aktiviert oder deaktiviert.
+   - Die `CombinationSelectionPage` erlaubt die Gewichtung der Kombinationen. Über `BewertungsOptionen.tsx` lassen sich weitere Optionen wählen.
+   - Alle Texte stammen aus `src/i18n/common.ts` und werden zentral über `src/i18n/index.ts` geladen.
 
-3. **Ranking**
-   - Zeigt sortierte Ergebnisliste nach Score (Platz 1
+3. **Persönliche Angaben & Zusammenfassung**
+   - Die `PersonalDataPage` sammelt optionale Statistikdaten.
+   - Anschließend zeigt die `ConfigSummaryPage` einen Überblick aller Einstellungen.
+
+4. **Berechnung & Ergebnisse**
+   - Das Backend ruft die Bewertungslogik (`bewertung.py`) auf und speichert den Lauf über die Route `save_run`.
+   - Die `CalcResultsPage` präsentiert das Ranking der Ideen.
 
 
 ## ⚙️ Backend-Komponenten (FastAPI)
@@ -141,4 +156,4 @@ Alle Dateien befinden sich unter:
 
 ---
 
-*Letzte Aktualisierung durch ChatGPT: (28.05.2025:13:03)*
+*Letzte Aktualisierung durch ChatGPT: (20.06.2025:10:15)*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -270,11 +270,12 @@ const handleKombiSammlungChange = (dateiName: string) => {
   }, [loadIdeen, loadKombis]);
 
   return (
-    <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center py-10">
-      <div className="w-full max-w-7xl bg-gray-800 text-white shadow-xl rounded-2xl p-8 relative">
-        <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-white/90 px-3 py-2 rounded-xl shadow border">
+    <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center justify-center py-10">
+      <div className="fixed top-4 left-4 z-50 bg-white/90 px-3 py-2 rounded-xl shadow border text-sm font-mono">
+        Session ID: {sessionId}
+      </div>
+      <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-white/90 px-3 py-2 rounded-xl shadow border">
 
-          <label htmlFor="lang-select" className="font-semibold text-sm">{t("language")}</label>
           <select
             id="lang-select"
             value={language}
@@ -287,7 +288,6 @@ const handleKombiSammlungChange = (dateiName: string) => {
             <option value="fr">Français</option>
           </select>
         </div>
-      </div>
 
       <Routes>
         <Route path="/" element={<StartPage />} />
@@ -338,7 +338,10 @@ const handleKombiSammlungChange = (dateiName: string) => {
           path="/personal"
           element={(
             <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
-              <PersonalDataPage onOpenStatistikForm={openStatistikForm} />
+              <PersonalDataPage
+                onOpenStatistikForm={openStatistikForm}
+                onCloseStatistikForm={handleCloseStatistikForm}
+              />
             </div>
           )}
         />
@@ -368,6 +371,7 @@ const handleKombiSammlungChange = (dateiName: string) => {
       <StatistikForm
         open={statistikFormOpen}
         onClose={handleCloseStatistikForm}
+        tester={appTester}
         payload={{
           ideenSammlung: aktuelleIdeensammlung,
           kombiSammlung: "",

--- a/frontend/src/components/ResetButton.tsx
+++ b/frontend/src/components/ResetButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { resetSessionId } from '../utils/session';
+
+export const ResetButton: React.FC = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    resetSessionId();
+    navigate('/');
+  };
+
+  return (
+    <button onClick={handleClick} className="px-4 py-2 bg-gray-300 rounded">
+      {t('reset')}
+    </button>
+  );
+};
+
+export default ResetButton;

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -24,6 +24,7 @@ import { saveRun } from "../api/saveRun";
 type Props = {
   open: boolean;
   onClose: () => void;
+  tester: boolean;
   payload: Omit<BewertungsLaufPayload, "tester" | "userData">;
   onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
 };
@@ -31,6 +32,7 @@ type Props = {
 export const StatistikForm: React.FC<Props> = ({
   open,
   onClose,
+  tester,
   payload,
   onSaveSuccess,
 }) => {
@@ -40,7 +42,6 @@ export const StatistikForm: React.FC<Props> = ({
   const [geschlecht, setGeschlecht] = useState("");
   const [branche, setBranche] = useState("");
   const [berufsrolle, setBerufsrolle] = useState("");
-  const [tester, setTester] = useState(false);
   const [sending, setSending] = useState(false);
   const [fehler, setFehler] = useState<string | null>(null);
 
@@ -50,6 +51,12 @@ export const StatistikForm: React.FC<Props> = ({
     e.preventDefault();
     setSending(true);
     setFehler(null);
+
+    if (!tester && (!alter || !geschlecht || !branche || !berufsrolle)) {
+      setFehler(t('fieldsRequired'));
+      setSending(false);
+      return;
+    }
 
     const fullPayload: BewertungsLaufPayload = {
       ...payload,
@@ -94,16 +101,6 @@ export const StatistikForm: React.FC<Props> = ({
           className="text-gray-700 text-sm mb-4"
           dangerouslySetInnerHTML={{ __html: t("infoVoluntary") }}
         />
-
-        <label className="block mb-2 font-semibold">
-          <input
-            type="checkbox"
-            checked={tester}
-            onChange={() => setTester((v) => !v)}
-            className="mr-2"
-          />
-          {t("appTesterMode")}
-        </label>
 
         {!tester && (
           <div className="space-y-2 mb-3">

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -35,6 +35,8 @@ const common = {
         optionDataReleaseOpen: "Bitte geben Sie Ihre Daten ein (anonym)",
         optionDataReleaseAnonym: "Nur Ihr Nutzungsverhalten wird gespeichert",
         optionDataReleaseNone: "Es werden keine Daten gespeichert",
+        introText: "Mit diesem Tool können Sie Ideen bewerten und kombinieren.",
+        fieldsRequired: "Bitte alle Felder ausfüllen.",
 
         currentIdeaCollection: "Aktuelle Ideensammlung",
         currentCombinationCollection: "Aktuelle Kombinationssammlung",
@@ -131,6 +133,8 @@ const common = {
         optionDataReleaseOpen: "Please enter your data (anonymous)",
         optionDataReleaseAnonym: "Only your usage behavior will be saved",
         optionDataReleaseNone: "No data will be saved",
+        introText: "This tool lets you rate and combine ideas.",
+        fieldsRequired: "Please fill in all fields.",
 
         currentIdeaCollection: "Current idea collection",
         currentCombinationCollection: "Current combination collection",
@@ -227,6 +231,8 @@ const common = {
         optionDataReleaseOpen: "Veuillez entrer vos données (anonymes)",
         optionDataReleaseAnonym: "Seul votre comportement d'utilisation sera enregistré",
         optionDataReleaseNone: "Aucune donnée ne sera enregistrée",
+        introText: "Cet outil vous permet d'évaluer et de combiner des idées.",
+        fieldsRequired: "Veuillez remplir tous les champs.",
 
         currentIdeaCollection: "Collection d'idées actuelle",
         currentCombinationCollection: "Collection de combinaisons actuelle",

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -3,6 +3,7 @@ import { WeightingSelector } from '../components/WeightingSelector';
 import { BewertungsOptionen } from '../components/BewertungsOptionen';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { ResetButton } from '../components/ResetButton';
 
 interface Props {
   gewichtungen: any[];
@@ -37,8 +38,15 @@ export const CombinationSelectionPage = ({
         />
       </div>
       <div className="mt-6 flex justify-between">
-        <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">{t('back')}</Link>
-        <Link to="/personal" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">{t('next')}</Link>
+        <ResetButton />
+        <div className="flex gap-4">
+          <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/personal" className="px-4 py-2 bg-blue-600 text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -47,17 +47,12 @@ export const ConfigPage = ({
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       <div className="mt-6 text-center">
-
-        <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-
         <Link
           to="/results"
           onClick={onOpenStatistikForm}
-          className="px-4 py-2 bg-[#1d2c5b] text-white rounded"
+          className="px-4 py-2 bg-blue-600 text-white rounded"
         >
-          
-
+          {t('next')}
         </Link>
       </div>
     </div>

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { ResetButton } from '../components/ResetButton';
 
 interface Props {
   ideenCount: number;
@@ -28,12 +29,15 @@ export const ConfigSummaryPage = ({
         </li>
       </ul>
       <div className="mt-6 flex justify-between">
-        <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
-        </Link>
-        <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('calculate')}
-        </Link>
+        <ResetButton />
+        <div className="flex gap-4">
+          <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/results" className="px-4 py-2 bg-blue-600 text-white rounded">
+            {t('calculate')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IdeenSelector } from '../components/IdeenSelector';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { ResetButton } from '../components/ResetButton';
 
 interface Props {
   ideen: any[];
@@ -15,12 +16,15 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
     <div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
       <div className="mt-6 flex justify-between">
-        <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
-        </Link>
-        <Link to="/combinations" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-        </Link>
+        <ResetButton />
+        <div className="flex gap-4">
+          <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/combinations" className="px-4 py-2 bg-blue-600 text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -1,28 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { ResetButton } from '../components/ResetButton';
 
 interface Props {
   onOpenStatistikForm: () => void;
+  onCloseStatistikForm: () => void;
 }
 
-export const PersonalDataPage = ({ onOpenStatistikForm }: Props) => {
+export const PersonalDataPage = ({
+  onOpenStatistikForm,
+  onCloseStatistikForm,
+}: Props) => {
   const { t } = useTranslation();
+  useEffect(() => {
+    onOpenStatistikForm();
+    return onCloseStatistikForm;
+  }, [onOpenStatistikForm, onCloseStatistikForm]);
   return (
     <div className="text-center">
-      <button
-        onClick={onOpenStatistikForm}
-        className="px-4 py-2 bg-gray-200 rounded mb-4"
-      >
-        {t('optionDataReleaseOpen')}
-      </button>
       <div className="mt-6 flex justify-between">
-        <Link to="/combinations" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
-        </Link>
-        <Link to="/summary" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-        </Link>
+        <ResetButton />
+        <div className="flex gap-4">
+          <Link to="/combinations" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/summary" className="px-4 py-2 bg-blue-600 text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CollectionSelectorIdeas } from '../components/CollectionSelectorIdeas';
 import { CollectionSelectorKombis } from '../components/CollectionSelectorKombis';
 import { Link } from 'react-router-dom';
+import { ResetButton } from '../components/ResetButton';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -35,12 +36,15 @@ export const SelectDataPage = ({
         onUpload={onKombiUpload}
       />
       <div className="mt-6 flex justify-between">
-        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-          {t('back')}
-        </Link>
-        <Link to="/ideas" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-          {t('next')}
-        </Link>
+        <ResetButton />
+        <div className="flex gap-4">
+          <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+            {t('back')}
+          </Link>
+          <Link to="/ideas" className="px-4 py-2 bg-blue-600 text-white rounded">
+            {t('next')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/StartPage.tsx
+++ b/frontend/src/pages/StartPage.tsx
@@ -9,7 +9,8 @@ export const StartPage = () => {
       <h1 className="text-4xl font-bold mb-8 text-[#1d2c5b] tracking-tight drop-shadow">
         {t('title')}
       </h1>
-      <Link to="/select-data" className="mt-4 inline-block px-4 py-2 bg-[#1d2c5b] text-white rounded">
+      <p className="mb-6 text-gray-700">{t('introText')}</p>
+      <Link to="/select-data" className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">
         {t('start')}
       </Link>
     </div>

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -35,7 +35,7 @@ export const UploadPage = ({
         onUpload={onKombiUpload}
       />
       <div className="mt-6 text-center">
-        <Link to="/config" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+        <Link to="/config" className="px-4 py-2 bg-blue-600 text-white rounded">
           {t('next')}
         </Link>
       </div>

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -7,3 +7,9 @@ export function getSessionId(): string {
   }
   return sessionId;
 }
+
+export function resetSessionId(): string {
+  const newId = crypto.randomUUID();
+  sessionStorage.setItem("sessionId", newId);
+  return newId;
+}


### PR DESCRIPTION
## Summary
- show session ID in the corner and use a reset button component
- validate personal data form fields
- lighten action button colors
- add intro text and new translation strings

## Testing
- `pytest -q`
- `npm run lint` *(fails to read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1d4c30c832080f4b837c23de72b