### PR TITLE
Update linting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ VITE_I18N_DEBUG=true npm run dev
 
 ## Linting and type checking (offline)
 
-After the frontend dependencies have been installed once, the following commands
-can be executed without additional downloads:
+After the frontend dependencies have been installed once, run the lint and type
+checking commands from within the `frontend/` directory. Example:
 
 ```bash
+cd frontend
 npm run lint       # runs eslint on the frontend source
 npm run typecheck  # runs TypeScript type checking
 ```


### PR DESCRIPTION
## Summary
- clarify that linting and typechecking should run from `frontend/`
- show `cd frontend` in the example

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852de4d4f68832099469942086748da