### PR TITLE
Clean button layout and reposition header items

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -272,11 +272,11 @@ const handleKombiSammlungChange = (dateiName: string) => {
 
   return (
 
-    <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center justify-center py-10">
-      <div className="fixed top-4 left-4 z-50 bg-white/90 px-3 py-2 rounded-xl shadow border text-sm font-mono">
+    <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center justify-center py-10 relative">
+      <div className="absolute top-4 left-4 z-50 bg-white/90 px-3 py-2 rounded-xl shadow border text-sm font-mono">
         Session ID: {sessionId}
       </div>
-      <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-white/90 px-3 py-2 rounded-xl shadow border">
+      <div className="absolute top-4 right-4 z-50 flex items-center gap-2 bg-white/90 px-3 py-2 rounded-xl shadow border">
 
 
 

--- a/frontend/src/pages/CalcResultsPage.tsx
+++ b/frontend/src/pages/CalcResultsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Ranking } from '../components/Ranking';
 import { ExportRankingButton } from '../components/ExportRankingButton';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { hasSessionStarted } from '../utils/session';
 
@@ -22,9 +22,9 @@ export const CalcResultsPage = ({ rankingEintraege }: Props) => {
     <div>
       <Ranking eintraege={rankingEintraege} />
       <div className="mt-6 flex justify-between items-center gap-4">
-        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+        <button onClick={() => navigate('/')} className="px-4 py-2 bg-gray-300 rounded">
           {t('reset')}
-        </Link>
+        </button>
         <ExportRankingButton eintraege={rankingEintraege} />
       </div>
     </div>

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { WeightingSelector } from '../components/WeightingSelector';
 import { BewertungsOptionen } from '../components/BewertungsOptionen';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted } from '../utils/session';
@@ -38,12 +38,12 @@ export const CombinationSelectionPage = ({
       <div className="mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
-          <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">
+          <button onClick={() => navigate('/ideas')} className="px-4 py-2 bg-gray-300 rounded">
             {t('back')}
-          </Link>
-          <Link to="/personal" className="px-4 py-2 bg-blue-600 text-white rounded">
+          </button>
+          <button onClick={() => navigate('/personal')} className="px-4 py-2 bg-blue-600 text-white rounded">
             {t('next')}
-          </Link>
+          </button>
         </div>
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
@@ -56,24 +56,7 @@ export const CombinationSelectionPage = ({
           onChange={onOptionsChange}
         />
       </div>
-      <div className="mt-6 flex justify-between">
-
-        <ResetButton />
-
-        
-
-        <div className="flex gap-4">
-          <Link to="/ideas" className="px-4 py-2 bg-gray-300 rounded">
-            {t('back')}
-          </Link>
-
       
-          <Link to="/personal" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-
-            {t('next')}
-          </Link>
-        </div>
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IdeenSelector } from '../components/IdeenSelector';
 import { BewertungsOptionen } from '../components/BewertungsOptionen';
 import { WeightingSelector } from '../components/WeightingSelector';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -33,6 +33,7 @@ export const ConfigPage = ({
   onOpenStatistikForm = () => {},
 }: Props) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   return (
     <div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
@@ -47,13 +48,15 @@ export const ConfigPage = ({
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       <div className="mt-6 text-center">
-        <Link
-          to="/results"
-          onClick={onOpenStatistikForm}
+        <button
+          onClick={() => {
+            onOpenStatistikForm();
+            navigate('/results');
+          }}
           className="px-4 py-2 bg-blue-600 text-white rounded"
         >
           {t('next')}
-        </Link>
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted } from '../utils/session';
@@ -30,12 +30,12 @@ export const ConfigSummaryPage = ({
       <div className="mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
-          <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
+          <button onClick={() => navigate('/personal')} className="px-4 py-2 bg-gray-300 rounded">
             {t('back')}
-          </Link>
-          <Link to="/results" className="px-4 py-2 bg-blue-600 text-white rounded">
+          </button>
+          <button onClick={() => navigate('/results')} className="px-4 py-2 bg-blue-600 text-white rounded">
             {t('calculate')}
-          </Link>
+          </button>
         </div>
       </div>
       <h2 className="text-xl font-bold mb-4">{t('summary')}</h2>
@@ -47,23 +47,7 @@ export const ConfigSummaryPage = ({
           {t('currentCombinationCollection')}: {activeKombis} / {kombiCount}
         </li>
       </ul>
-      <div className="mt-6 flex justify-between">
-        <ResetButton />
-
-        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-          {t('reset')}
-        </Link>
-
-        <div className="flex gap-4">
-          <Link to="/personal" className="px-4 py-2 bg-gray-300 rounded">
-            {t('back')}
-          </Link>
-
-          <Link to="/results" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-            {t('calculate')}
-          </Link>
-        </div>
-      </div>
+      
     </div>
   );
 };

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { IdeenSelector } from '../components/IdeenSelector';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted } from '../utils/session';
@@ -25,29 +25,15 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
       <div className="mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
-          <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
+          <button onClick={() => navigate('/select-data')} className="px-4 py-2 bg-gray-300 rounded">
             {t('back')}
-          </Link>
-          <Link to="/combinations" className="px-4 py-2 bg-blue-600 text-white rounded">
+          </button>
+          <button onClick={() => navigate('/combinations')} className="px-4 py-2 bg-blue-600 text-white rounded">
             {t('next')}
-          </Link>
+          </button>
         </div>
       </div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
-      <div className="mt-6 flex justify-between">
-        <ResetButton />
-        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-          {t('reset')}
-        </Link>
-        <div className="flex gap-4">
-          <Link to="/select-data" className="px-4 py-2 bg-gray-300 rounded">
-            {t('back')}
-          </Link>
-          <Link to="/combinations" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-            {t('next')}
-          </Link>
-        </div>
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted } from '../utils/session';
@@ -29,17 +29,13 @@ export const PersonalDataPage = ({
     <div className="text-center">
       <div className="mb-6 flex justify-between">
         <ResetButton />
-        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-          {t('reset')}
-        </Link>
-
         <div className="flex gap-4">
-          <Link to="/combinations" className="px-4 py-2 bg-gray-300 rounded">
+          <button onClick={() => navigate('/combinations')} className="px-4 py-2 bg-gray-300 rounded">
             {t('back')}
-          </Link>
-          <Link to="/summary" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+          </button>
+          <button onClick={() => navigate('/summary')} className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
             {t('next')}
-          </Link>
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { CollectionSelectorIdeas } from '../components/CollectionSelectorIdeas';
 import { CollectionSelectorKombis } from '../components/CollectionSelectorKombis';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ResetButton } from '../components/ResetButton';
 import { useTranslation } from 'react-i18next';
 import { hasSessionStarted } from '../utils/session';
@@ -36,12 +36,18 @@ export const SelectDataPage = ({
       <div className="mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
-          <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
+          <button
+            onClick={() => navigate('/')}
+            className="px-4 py-2 bg-gray-300 rounded"
+          >
             {t('back')}
-          </Link>
-          <Link to="/ideas" className="px-4 py-2 bg-blue-600 text-white rounded">
+          </button>
+          <button
+            onClick={() => navigate('/ideas')}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
             {t('next')}
-          </Link>
+          </button>
         </div>
       </div>
       <CollectionSelectorIdeas
@@ -54,23 +60,6 @@ export const SelectDataPage = ({
         onSammlungChange={onKombiSammlungChange}
         onUpload={onKombiUpload}
       />
-      <div className="mt-6 flex justify-between">
-        <ResetButton />
-
-        <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-          {t('reset')}
-        </Link>
-
-        <div className="flex gap-4">
-          <Link to="/" className="px-4 py-2 bg-gray-300 rounded">
-            {t('back')}
-          </Link>
-
-          <Link to="/ideas" className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
-            {t('next')}
-          </Link>
-        </div>
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/StartPage.tsx
+++ b/frontend/src/pages/StartPage.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { markSessionStarted } from '../utils/session';
 
 export const StartPage = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   useEffect(() => {
     markSessionStarted();
   }, []);
@@ -14,9 +15,12 @@ export const StartPage = () => {
         {t('title')}
       </h1>
       <p className="mb-6 text-gray-700">{t('introText')}</p>
-      <Link to="/select-data" className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">
+      <button
+        onClick={() => navigate('/select-data')}
+        className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded"
+      >
         {t('start')}
-      </Link>
+      </button>
   
     </div>
   );

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CollectionSelectorIdeas } from '../components/CollectionSelectorIdeas';
 import { CollectionSelectorKombis } from '../components/CollectionSelectorKombis';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -22,6 +22,7 @@ export const UploadPage = ({
   onKombiUpload,
 }: Props) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   return (
     <div>
       <CollectionSelectorIdeas
@@ -35,9 +36,12 @@ export const UploadPage = ({
         onUpload={onKombiUpload}
       />
       <div className="mt-6 text-center">
-        <Link to="/config" className="px-4 py-2 bg-blue-600 text-white rounded">
+        <button
+          onClick={() => navigate('/config')}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
           {t('next')}
-        </Link>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- convert navigation links to buttons
- remove duplicate button rows across pages
- keep session id top-left and language selector top-right without fixed positioning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852fbe8fdc4832081d4a1917d0328b4