### PR TITLE
UI adjustments per feedback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,7 +66,7 @@ const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("default_komb
         return await response.json();
       } catch (err) {
         setStatusToastMessage(
-          `${t("uploadError")}: ${err instanceof Error ? err.message : String(err)}`,
+          `${t("loadError")}: ${err instanceof Error ? err.message : String(err)}`,
         );
         setStatusToastType("error");
         setStatusToastOpen(true);
@@ -272,10 +272,10 @@ const handleKombiSammlungChange = (dateiName: string) => {
 
   return (
 
-    <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center py-10 relative">
-      <header className="w-full bg-[#1d2c5b] text-white shadow-md mb-8">
+    <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center overflow-hidden py-10 relative">
+      <header className="w-full bg-blue-300 text-gray-900 shadow-md mb-8">
         <div className="max-w-5xl mx-auto flex justify-between items-center p-3">
-          <div className="text-xs font-mono">Session ID: {sessionId}</div>
+          <div className="text-xs font-mono bg-blue-100 text-blue-900 px-2 py-1 rounded">Session ID: {sessionId}</div>
           <select
             id="lang-select"
             value={language}

--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -135,7 +135,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         ))}
       </select>
       <div className="mt-2 flex items-center space-x-4">
-        <label className="cursor-pointer text-blue-600 underline">
+        <label className="cursor-pointer px-4 py-2 bg-blue-600 text-white rounded inline-block">
           {t("uploadFile")}
           <input
             type="file"
@@ -148,7 +148,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         <a
           href={`${backendUrl}/download_template?type=ideen`}
           download
-          className="text-blue-600 underline"
+          className="px-4 py-2 bg-gray-300 rounded inline-block"
           target="_blank"
           rel="noreferrer"
         >

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -135,7 +135,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         ))}
       </select>
       <div className="mt-2 flex items-center space-x-4">
-        <label className="cursor-pointer text-blue-600 underline">
+        <label className="cursor-pointer px-4 py-2 bg-blue-600 text-white rounded inline-block">
           {t("uploadFile")}
           <input
             type="file"
@@ -148,7 +148,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         <a
           href={`${backendUrl}/download_template?type=kombi`}
           download
-          className="text-blue-600 underline"
+          className="px-4 py-2 bg-gray-300 rounded inline-block"
           target="_blank"
           rel="noreferrer"
         >

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -95,6 +95,8 @@ const common = {
         uploadError: "Upload fehlgeschlagen",
         uploadnotvalid: "Hochgeladene Datei muss der Struktur der Vorlage entsprechen.",
         uploadSuccess: "Upload erfolgreich",
+        loadError: "Laden fehlgeschlagen",
+        noDataLoaded: "Keine Daten geladen",
       },
     },
     en: {
@@ -193,6 +195,8 @@ const common = {
         uploadError: "Upload failed",
         uploadnotvalid: "Uploaded file must match the template structure.",
         uploadSuccess: "Upload successful",
+        loadError: "Loading failed",
+        noDataLoaded: "No data loaded",
       },
     },
     fr: {
@@ -293,7 +297,9 @@ const common = {
         uploadError: "Échec du téléchargement",
         uploadnotvalid: "Le fichier téléchargé doit respecter la structure du modèle.",
         uploadSuccess: "Téléversement réussi",
+        loadError: "Échec du chargement",
+        noDataLoaded: "Aucune donnée chargée",
       },
     },
-};
+  };
 export default common;

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -35,7 +35,7 @@ export const CombinationSelectionPage = ({
   }, [navigate]);
   return (
     <div>
-      <div className="mb-6 flex justify-between">
+      <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
           <button onClick={() => navigate('/ideas')} className="px-4 py-2 bg-gray-300 rounded">

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -19,6 +19,15 @@ export const ConfigSummaryPage = ({
 }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const disabled = ideenCount === 0 || kombiCount === 0;
+
+  const handleCalculate = () => {
+    if (disabled) {
+      alert(t('noDataLoaded'));
+      return;
+    }
+    navigate('/results');
+  };
 
   useEffect(() => {
     if (!hasSessionStarted()) {
@@ -27,13 +36,21 @@ export const ConfigSummaryPage = ({
   }, [navigate]);
   return (
     <div>
-      <div className="mb-6 flex justify-between">
+      <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
           <button onClick={() => navigate('/personal')} className="px-4 py-2 bg-gray-300 rounded">
             {t('back')}
           </button>
-          <button onClick={() => navigate('/results')} className="px-4 py-2 bg-blue-600 text-white rounded">
+          <button
+            onClick={handleCalculate}
+            disabled={disabled}
+            className={
+              disabled
+                ? 'px-4 py-2 bg-gray-300 rounded cursor-not-allowed'
+                : 'px-4 py-2 bg-blue-600 text-white rounded'
+            }
+          >
             {t('calculate')}
           </button>
         </div>

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -22,7 +22,7 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
   }, [navigate]);
   return (
     <div>
-      <div className="mb-6 flex justify-between">
+      <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
           <button onClick={() => navigate('/select-data')} className="px-4 py-2 bg-gray-300 rounded">

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -27,13 +27,13 @@ export const PersonalDataPage = ({
   }, [navigate]);
   return (
     <div className="text-center">
-      <div className="mb-6 flex justify-between">
+      <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
           <button onClick={() => navigate('/combinations')} className="px-4 py-2 bg-gray-300 rounded">
             {t('back')}
           </button>
-          <button onClick={() => navigate('/summary')} className="px-4 py-2 bg-[#1d2c5b] text-white rounded">
+          <button onClick={() => navigate('/summary')} className="px-4 py-2 bg-gray-300 rounded">
             {t('next')}
           </button>
         </div>

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -33,7 +33,7 @@ export const SelectDataPage = ({
   }, [navigate]);
   return (
     <div>
-      <div className="mb-6 flex justify-between">
+      <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />
         <div className="flex gap-4">
           <button


### PR DESCRIPTION
## Summary
- keep header static and light blue
- prevent scrolling and keep session ID on a light badge
- match "next" button color on personal page with other buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `pytest -q` *(no tests ran)*
- `bash ./codex-setup.sh` *(fails to fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853003a24108320a01fcf53e02d1fbd