### PR TITLE
UI improvements for select-data and load fix

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -161,8 +161,19 @@ async def delete_uploaded_file(sammlung_typ: str, session: str, filename: str, l
 # ---- Dateiinhalt anzeigen (Excel als JSON) ----
 @app.get("/api/uploads/{sammlung_typ}/content")
 async def read_uploaded_file(sammlung_typ: str, session: str, filename: str, lang: str = Query("de")):
-    file_path = UPLOAD_BASE / session / sammlung_typ / filename
-    if not file_path.exists():
+    user_path = UPLOAD_BASE / session / sammlung_typ / filename
+    if sammlung_typ == "ideen":
+        global_path = Path(config.selectionideas_dir) / filename
+    elif sammlung_typ == "kombis":
+        global_path = Path(config.selectioncombis_dir) / filename
+    else:
+        global_path = None
+
+    if user_path.exists():
+        file_path = user_path
+    elif global_path and global_path.exists():
+        file_path = global_path
+    else:
         return JSONResponse(status_code=404, content={"error": t("file_not_found", lang)})
 
     try:

--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { getSessionId } from "@/utils/session";
 
@@ -19,6 +19,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   const [auswahl, setAuswahl] = useState<string>(aktuelleSammlungName);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [fileKey, setFileKey] = useState<number>(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [eigeneSammlungenState, setEigeneSammlungen] = useState<string[]>(eigeneSammlungen);
   const sessionId = getSessionId();
 
@@ -53,6 +54,10 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         console.error("Fehler beim Abrufen der Dateiliste:", err);
       });
   }, [sessionId]);
+
+  const handleUploadButtonClick = () => {
+    fileInputRef.current?.click();
+  };
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUploadError(null);
@@ -135,25 +140,28 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         ))}
       </select>
       <div className="mt-2 flex items-center space-x-4">
-        <label className="cursor-pointer px-4 py-2 bg-blue-600 text-white rounded inline-block">
+        <button
+          type="button"
+          onClick={handleUploadButtonClick}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
           {t("uploadFile")}
-          <input
-            type="file"
-            accept=".xlsx"
-            onChange={handleUpload}
-            className="hidden"
-            key={fileKey}
-          />
-        </label>
-        <a
-          href={`${backendUrl}/download_template?type=ideen`}
-          download
-          className="px-4 py-2 bg-gray-300 rounded inline-block"
-          target="_blank"
-          rel="noreferrer"
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xlsx"
+          onChange={handleUpload}
+          className="hidden"
+          key={fileKey}
+        />
+        <button
+          type="button"
+          onClick={() => window.open(`${backendUrl}/download_template?type=ideen`, '_blank')}
+          className="px-4 py-2 bg-gray-300 rounded"
         >
           {t("downloadIdeaTemplate")}
-        </a>
+        </button>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { getSessionId } from "@/utils/session";
 
@@ -19,6 +19,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
   const [auswahl, setAuswahl] = useState<string>(aktuelleSammlungName);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [fileKey, setFileKey] = useState<number>(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [eigeneSammlungenState, setEigeneSammlungen] = useState<string[]>(eigeneSammlungen);
   const sessionId = getSessionId();
 
@@ -54,6 +55,10 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         console.error("Fehler beim Abrufen der Dateiliste:", err);
       });
   }, [sessionId]);
+
+  const handleUploadButtonClick = () => {
+    fileInputRef.current?.click();
+  };
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUploadError(null);
@@ -135,25 +140,28 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         ))}
       </select>
       <div className="mt-2 flex items-center space-x-4">
-        <label className="cursor-pointer px-4 py-2 bg-blue-600 text-white rounded inline-block">
+        <button
+          type="button"
+          onClick={handleUploadButtonClick}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
           {t("uploadFile")}
-          <input
-            type="file"
-            accept=".xlsx"
-            onChange={handleUpload}
-            className="hidden"
-            key={fileKey}
-          />
-        </label>
-        <a
-          href={`${backendUrl}/download_template?type=kombi`}
-          download
-          className="px-4 py-2 bg-gray-300 rounded inline-block"
-          target="_blank"
-          rel="noreferrer"
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xlsx"
+          onChange={handleUpload}
+          className="hidden"
+          key={fileKey}
+        />
+        <button
+          type="button"
+          onClick={() => window.open(`${backendUrl}/download_template?type=kombi`, '_blank')}
+          className="px-4 py-2 bg-gray-300 rounded"
         >
           {t("downloadCombinationTemplate")}
-        </a>
+        </button>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>


### PR DESCRIPTION
## Summary
- style download template and upload actions as buttons
- fallback to global collections when session file missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685313ead3988320ab4d51fab47870ed