### PR TITLE
UI form tweaks and summary guard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -161,8 +161,19 @@ async def delete_uploaded_file(sammlung_typ: str, session: str, filename: str, l
 # ---- Dateiinhalt anzeigen (Excel als JSON) ----
 @app.get("/api/uploads/{sammlung_typ}/content")
 async def read_uploaded_file(sammlung_typ: str, session: str, filename: str, lang: str = Query("de")):
-    file_path = UPLOAD_BASE / session / sammlung_typ / filename
-    if not file_path.exists():
+    user_path = UPLOAD_BASE / session / sammlung_typ / filename
+    if sammlung_typ == "ideen":
+        global_path = Path(config.selectionideas_dir) / filename
+    elif sammlung_typ == "kombis":
+        global_path = Path(config.selectioncombis_dir) / filename
+    else:
+        global_path = None
+
+    if user_path.exists():
+        file_path = user_path
+    elif global_path and global_path.exists():
+        file_path = global_path
+    else:
         return JSONResponse(status_code=404, content={"error": t("file_not_found", lang)})
 
     try:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
   const [saveRunMessage, setSaveRunMessage] = useState("");
   const [saveRunId, setSaveRunId] = useState<string | undefined>(undefined);
   const [statistikFormOpen, setStatistikFormOpen] = useState(false);
+  const [statistikFormInline, setStatistikFormInline] = useState(false);
   const [statusToastOpen, setStatusToastOpen] = useState(false);
   const [statusToastMessage, setStatusToastMessage] = useState("");
   const [statusToastType, setStatusToastType] = useState<"success" | "error" | "info">("info");
@@ -246,12 +247,14 @@ const handleKombiSammlungChange = (dateiName: string) => {
     setSaveRunId(undefined);
   };
 
-  const openStatistikForm = () => {
+  const openStatistikForm = (inline: boolean = false) => {
+    setStatistikFormInline(inline);
     setStatistikFormOpen(true);
   };
 
   const handleCloseStatistikForm = () => {
     setStatistikFormOpen(false);
+    setStatistikFormInline(false);
   };
 
   const handleSaveSuccess = (result: { run_id?: string; message: string }) => {
@@ -272,8 +275,8 @@ const handleKombiSammlungChange = (dateiName: string) => {
 
 return (
   <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center pb-10">
-    <header className="w-full bg-blue-300 text-white shadow-md mb-4">
-      <div className="max-w-5xl mx-auto flex justify-between items-center p-3">
+    <header className="w-[85%] mx-auto bg-blue-300 text-white shadow-md mb-4">
+      <div className="flex justify-between items-center p-3">
         <div className="text-xs font-mono bg-blue-100 text-blue-900 px-2 py-1 rounded">
           Session ID: {sessionId}
         </div>
@@ -297,7 +300,7 @@ return (
         <Route
           path="/select-data"
           element={(
-            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+            <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 min-h-[80vh]">
               <SelectDataPage
                 aktuelleIdeensammlung={aktuelleIdeensammlung}
                 aktuelleKombiSammlung={aktuelleKombiSammlung}
@@ -312,7 +315,7 @@ return (
         <Route
           path="/ideas"
           element={(
-            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+            <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
               <IdeaSelectionPage
                 ideen={ideen}
                 sprache={language as "de" | "en" | "fr"}
@@ -324,7 +327,7 @@ return (
         <Route
           path="/combinations"
           element={(
-            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+            <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
               <CombinationSelectionPage
                 gewichtungen={gewichtungen}
                 runde1={runde1}
@@ -340,9 +343,9 @@ return (
         <Route
           path="/personal"
           element={(
-            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+            <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 min-h-[80vh]">
               <PersonalDataPage
-                onOpenStatistikForm={openStatistikForm}
+                onOpenStatistikForm={() => openStatistikForm(true)}
                 onCloseStatistikForm={handleCloseStatistikForm}
               />
             </div>
@@ -351,7 +354,7 @@ return (
         <Route
           path="/summary"
           element={(
-            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+            <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 min-h-[80vh]">
               <ConfigSummaryPage
                 ideenCount={ideen.length}
                 activeIdeen={ideen.filter((i) => i.aktiv).length}
@@ -364,7 +367,7 @@ return (
         <Route
           path="/results"
           element={(
-            <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
+            <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10">
               <CalcResultsPage rankingEintraege={rankingEintraege} />
             </div>
           )}
@@ -373,6 +376,7 @@ return (
 
       <StatistikForm
         open={statistikFormOpen}
+        inline={statistikFormInline}
         onClose={handleCloseStatistikForm}
         tester={appTester}
         payload={{

--- a/frontend/src/components/BewertungsOptionen.tsx
+++ b/frontend/src/components/BewertungsOptionen.tsx
@@ -7,6 +7,7 @@ type BewertungsOptionenProps = {
   appTester: boolean;
   datenfreigabe: "offen" | "anonym" | "keine";
   onChange: (field: string, value: any) => void;
+  showDataRelease?: boolean;
 };
 
 export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
@@ -15,6 +16,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
   appTester,
   datenfreigabe,
   onChange,
+  showDataRelease = true,
 }) => {
   const { t } = useTranslation();
 
@@ -55,18 +57,20 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
         </label>
       </div>
 
-      <div className="mt-2 text-center">
-        <label className="block mb-1 font-medium">{t("optionDataRelease")}</label>
-        <select
-          value={datenfreigabe}
-          onChange={(e) => onChange("datenfreigabe", e.target.value)}
-          className="border p-2 rounded w-full max-w-xs mx-auto"
-        >
-          <option value="offen">{t("optionDataReleaseOpen")}</option>
-          <option value="anonym">{t("optionDataReleaseAnonym")}</option>
-          <option value="keine">{t("optionDataReleaseNone")}</option>
-        </select>
-      </div>
+      {showDataRelease && (
+        <div className="mt-2 text-center">
+          <label className="block mb-1 font-medium">{t("optionDataRelease")}</label>
+          <select
+            value={datenfreigabe}
+            onChange={(e) => onChange("datenfreigabe", e.target.value)}
+            className="border p-2 rounded w-full max-w-xs mx-auto"
+          >
+            <option value="offen">{t("optionDataReleaseOpen")}</option>
+            <option value="anonym">{t("optionDataReleaseAnonym")}</option>
+            <option value="keine">{t("optionDataReleaseNone")}</option>
+          </select>
+        </div>
+      )}
    
     </div>
   );

--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { getSessionId } from "@/utils/session";
 
@@ -19,6 +19,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   const [auswahl, setAuswahl] = useState<string>(aktuelleSammlungName);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [fileKey, setFileKey] = useState<number>(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [eigeneSammlungenState, setEigeneSammlungen] = useState<string[]>(eigeneSammlungen);
   const sessionId = getSessionId();
 
@@ -53,6 +54,10 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         console.error("Fehler beim Abrufen der Dateiliste:", err);
       });
   }, [sessionId]);
+
+  const handleUploadButtonClick = () => {
+    fileInputRef.current?.click();
+  };
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUploadError(null);
@@ -135,25 +140,28 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         ))}
       </select>
       <div className="mt-2 flex items-center space-x-4">
-        <label className="cursor-pointer px-4 py-2 bg-blue-600 text-white rounded inline-block">
+        <button
+          type="button"
+          onClick={handleUploadButtonClick}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
           {t("uploadFile")}
-          <input
-            type="file"
-            accept=".xlsx"
-            onChange={handleUpload}
-            className="hidden"
-            key={fileKey}
-          />
-        </label>
-        <a
-          href={`${backendUrl}/download_template?type=ideen`}
-          download
-          className="px-4 py-2 bg-gray-300 rounded inline-block"
-          target="_blank"
-          rel="noreferrer"
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xlsx"
+          onChange={handleUpload}
+          className="hidden"
+          key={fileKey}
+        />
+        <button
+          type="button"
+          onClick={() => window.open(`${backendUrl}/download_template?type=ideen`, '_blank')}
+          className="px-4 py-2 bg-gray-300 rounded"
         >
           {t("downloadIdeaTemplate")}
-        </a>
+        </button>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { getSessionId } from "@/utils/session";
 
@@ -19,6 +19,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
   const [auswahl, setAuswahl] = useState<string>(aktuelleSammlungName);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [fileKey, setFileKey] = useState<number>(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [eigeneSammlungenState, setEigeneSammlungen] = useState<string[]>(eigeneSammlungen);
   const sessionId = getSessionId();
 
@@ -54,6 +55,10 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         console.error("Fehler beim Abrufen der Dateiliste:", err);
       });
   }, [sessionId]);
+
+  const handleUploadButtonClick = () => {
+    fileInputRef.current?.click();
+  };
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUploadError(null);
@@ -135,25 +140,28 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         ))}
       </select>
       <div className="mt-2 flex items-center space-x-4">
-        <label className="cursor-pointer px-4 py-2 bg-blue-600 text-white rounded inline-block">
+        <button
+          type="button"
+          onClick={handleUploadButtonClick}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
           {t("uploadFile")}
-          <input
-            type="file"
-            accept=".xlsx"
-            onChange={handleUpload}
-            className="hidden"
-            key={fileKey}
-          />
-        </label>
-        <a
-          href={`${backendUrl}/download_template?type=kombi`}
-          download
-          className="px-4 py-2 bg-gray-300 rounded inline-block"
-          target="_blank"
-          rel="noreferrer"
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xlsx"
+          onChange={handleUpload}
+          className="hidden"
+          key={fileKey}
+        />
+        <button
+          type="button"
+          onClick={() => window.open(`${backendUrl}/download_template?type=kombi`, '_blank')}
+          className="px-4 py-2 bg-gray-300 rounded"
         >
           {t("downloadCombinationTemplate")}
-        </a>
+        </button>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -27,6 +27,7 @@ type Props = {
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, "tester" | "userData">;
   onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
+  inline?: boolean;
 };
 
 export const StatistikForm: React.FC<Props> = ({
@@ -35,6 +36,7 @@ export const StatistikForm: React.FC<Props> = ({
   tester,
   payload,
   onSaveSuccess,
+  inline = false,
 }) => {
   const { t } = useTranslation();
 
@@ -44,8 +46,6 @@ export const StatistikForm: React.FC<Props> = ({
   const [berufsrolle, setBerufsrolle] = useState("");
   const [sending, setSending] = useState(false);
   const [fehler, setFehler] = useState<string | null>(null);
-
-  if (!open) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -81,6 +81,85 @@ export const StatistikForm: React.FC<Props> = ({
       setSending(false);
     }
   };
+
+  if (!open) return null;
+
+  if (inline) {
+    return (
+      <div className="flex justify-center">
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-xl p-6 shadow-xl max-w-md w-full relative"
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute top-2 right-3 text-gray-500 hover:text-black text-xl"
+            aria-label={t("close")}
+          >
+            ×
+          </button>
+          <h2 className="font-bold text-lg mb-2">{t("helpImproveStats")}</h2>
+          <p
+            className="text-gray-700 text-sm mb-4"
+            dangerouslySetInnerHTML={{ __html: t("infoVoluntary") }}
+          />
+          {!tester && (
+            <div className="space-y-2 mb-3">
+              <input
+                className="border p-2 rounded w-full"
+                type="text"
+                placeholder={t("age")}
+                value={alter}
+                onChange={(e) => setAlter(e.target.value)}
+              />
+              <input
+                className="border p-2 rounded w-full"
+                type="text"
+                placeholder={t("gender")}
+                value={geschlecht}
+                onChange={(e) => setGeschlecht(e.target.value)}
+              />
+              <input
+                className="border p-2 rounded w-full"
+                type="text"
+                placeholder={t("industry")}
+                value={branche}
+                onChange={(e) => setBranche(e.target.value)}
+              />
+              <input
+                className="border p-2 rounded w-full"
+                type="text"
+                placeholder={t("jobRole")}
+                value={berufsrolle}
+                onChange={(e) => setBerufsrolle(e.target.value)}
+              />
+            </div>
+          )}
+
+          {fehler && <div className="text-red-600 text-sm mb-2">{fehler}</div>}
+
+          <div className="flex gap-3 mt-4">
+            <button
+              type="submit"
+              disabled={sending}
+              className="bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700"
+            >
+              {tester ? t("submitWithoutData") : t("saveRating")}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={sending}
+              className="bg-gray-200 rounded px-4 py-2"
+            >
+              {t("cancel")}
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex items-center justify-center">

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -54,6 +54,7 @@ export const CombinationSelectionPage = ({
           appTester={appTester}
           datenfreigabe={datenfreigabe}
           onChange={onOptionsChange}
+          showDataRelease={false}
         />
       </div>
       

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -16,7 +16,7 @@ interface Props {
   onIdeenUpdate: (ideen: any[]) => void;
   onBewertungsOptionenChange: (field: string, value: any) => void;
   onGewichtungenUpdate: (g: any[]) => void;
-  onOpenStatistikForm?: () => void;
+  onOpenStatistikForm?: (inline?: boolean) => void;
 }
 
 export const ConfigPage = ({
@@ -50,7 +50,7 @@ export const ConfigPage = ({
       <div className="mt-6 text-center">
         <button
           onClick={() => {
-            onOpenStatistikForm();
+            onOpenStatistikForm && onOpenStatistikForm(false);
             navigate('/results');
           }}
           className="px-4 py-2 bg-blue-600 text-white rounded"

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -19,7 +19,7 @@ export const ConfigSummaryPage = ({
 }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const disabled = ideenCount === 0 || kombiCount === 0;
+  const disabled = activeIdeen === 0 || activeKombis === 0;
 
   const handleCalculate = () => {
     if (disabled) {

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -5,7 +5,7 @@ import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted } from '../utils/session';
 
 interface Props {
-  onOpenStatistikForm: () => void;
+  onOpenStatistikForm: (inline?: boolean) => void;
   onCloseStatistikForm: () => void;
 }
 
@@ -16,7 +16,7 @@ export const PersonalDataPage = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   useEffect(() => {
-    onOpenStatistikForm();
+    onOpenStatistikForm(true);
     return onCloseStatistikForm;
   }, [onOpenStatistikForm, onCloseStatistikForm]);
 

--- a/frontend/src/pages/StartPage.tsx
+++ b/frontend/src/pages/StartPage.tsx
@@ -10,7 +10,7 @@ export const StartPage = () => {
     markSessionStarted();
   }, []);
   return (
-    <div className="max-w-5xl w-full mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 text-center">
+    <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 text-center min-h-[80vh]">
       <h1 className="text-4xl font-bold mb-8 text-[#1d2c5b] tracking-tight drop-shadow">
         {t('title')}
       </h1>


### PR DESCRIPTION
## Summary
- hide data release options on combination page
- center personal data form and allow scrolling
- disable calculation when no active ideas or combos

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685313ead3988320ab4d51fab47870ed