### PR TITLE
Fix personal data form duplication

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -355,10 +355,6 @@ return (
                   ergebnisRanking: [],
                 }}
                 onSaveSuccess={handleSaveSuccess}
-
-                onOpenStatistikForm={() => openStatistikForm(true)}
-                onCloseStatistikForm={handleCloseStatistikForm}
-
               />
             </div>
           )}

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -91,14 +91,16 @@ export const StatistikForm: React.FC<Props> = ({
           onSubmit={handleSubmit}
           className="bg-white rounded-xl p-6 shadow-xl max-w-md w-full relative"
         >
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute top-2 right-3 text-gray-500 hover:text-black text-xl"
-            aria-label={t("close")}
-          >
-            ×
-          </button>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="absolute top-2 right-3 text-gray-500 hover:text-black text-xl"
+              aria-label={t("close")}
+            >
+              ×
+            </button>
+          )}
 
 
           <h2 className="font-bold text-lg mb-2">{t("helpImproveStats")}</h2>
@@ -150,24 +152,17 @@ export const StatistikForm: React.FC<Props> = ({
             >
               {tester ? t("submitWithoutData") : t("saveRating")}
             </button>
+            {onClose && (
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={sending}
+                className="bg-gray-200 rounded px-4 py-2"
+              >
+                {t("cancel")}
+              </button>
+            )}
           </div>
-       <div className="flex gap-3 mt-4">
-  <button
-    type="submit"
-    disabled={sending || (!tester && (!alter || !geschlecht || !branche || !berufsrolle))}
-    className="bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700 disabled:opacity-50"
-  >
-    {tester ? t("submitWithoutData") : t("saveRating")}
-  </button>
-  <button
-    type="button"
-    onClick={onClose}
-    disabled={sending}
-    className="bg-gray-200 rounded px-4 py-2"
-  >
-    {t("cancel")}
-  </button>
-</div>
 
         </form>
       </div>

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -10,26 +10,18 @@ interface Props {
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, 'tester' | 'userData'>;
   onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
-  onOpenStatistikForm: (inline?: boolean) => void;
-  onCloseStatistikForm: () => void;
 }
 
 export const PersonalDataPage = ({
   tester,
   payload,
   onSaveSuccess,
-  onOpenStatistikForm,
-  onCloseStatistikForm,
 }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [formOpen, setFormOpen] = useState(true);
   const [saved, setSaved] = useState(false);
 
-  useEffect(() => {
-    onOpenStatistikForm(true);
-    return onCloseStatistikForm;
-  }, [onOpenStatistikForm, onCloseStatistikForm]);
 
   useEffect(() => {
     if (!hasSessionStarted()) {
@@ -61,7 +53,6 @@ export const PersonalDataPage = ({
             inline
             tester={tester}
             payload={payload}
-            onClose={() => setFormOpen(false)}
             onSaveSuccess={handleSaveSuccess}
           />
         </div>


### PR DESCRIPTION
## Summary
- remove automatic modal opening on `PersonalDataPage`
- hide close controls in `StatistikForm` when no `onClose` handler is given
- update routing usage of `PersonalDataPage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853318df8708320a7b9a8078ee3932e