### PR TITLE
Fix personal data page form duplication

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,6 @@ import { CalcResultsPage } from "./pages/CalcResultsPage";
 
 // import { KombiInfoModal } from "./components/KombiInfoModal"; // ← entfernt, da ungenutzt
 import { SaveRunSuccess } from "./components/SaveRunSuccess";
-import { StatistikForm } from "./components/StatistikForm";
 import { StatusToast } from "./components/StatusToast";
 
 import { getSessionId } from "./utils/session";
@@ -44,8 +43,6 @@ function App() {
   const [saveRunSuccessOpen, setSaveRunSuccessOpen] = useState(false);
   const [saveRunMessage, setSaveRunMessage] = useState("");
   const [saveRunId, setSaveRunId] = useState<string | undefined>(undefined);
-  const [statistikFormOpen, setStatistikFormOpen] = useState(false);
-  const [statistikFormInline, setStatistikFormInline] = useState(false);
   const [statusToastOpen, setStatusToastOpen] = useState(false);
   const [statusToastMessage, setStatusToastMessage] = useState("");
   const [statusToastType, setStatusToastType] = useState<"success" | "error" | "info">("info");
@@ -247,15 +244,6 @@ const handleKombiSammlungChange = (dateiName: string) => {
     setSaveRunId(undefined);
   };
 
-  const openStatistikForm = (inline: boolean = false) => {
-    setStatistikFormInline(inline);
-    setStatistikFormOpen(true);
-  };
-
-  const handleCloseStatistikForm = () => {
-    setStatistikFormOpen(false);
-    setStatistikFormInline(false);
-  };
 
   const handleSaveSuccess = (result: { run_id?: string; message: string }) => {
     setSaveRunId(result.run_id);
@@ -355,10 +343,6 @@ return (
                   ergebnisRanking: [],
                 }}
                 onSaveSuccess={handleSaveSuccess}
-
-                onOpenStatistikForm={() => openStatistikForm(true)}
-                onCloseStatistikForm={handleCloseStatistikForm}
-
               />
             </div>
           )}
@@ -386,21 +370,6 @@ return (
         />
       </Routes>
 
-      <StatistikForm
-        open={statistikFormOpen}
-        inline={statistikFormInline}
-        onClose={handleCloseStatistikForm}
-        tester={appTester}
-        payload={{
-          ideenSammlung: aktuelleIdeensammlung,
-          kombiSammlung: "",
-          gewaehlteIdeen: ideen.filter(i => i.aktiv).map(i => i.id),
-          deaktivierteIdeen: ideen.filter(i => !i.aktiv).map(i => i.id),
-          gewichtungen: {},
-          ergebnisRanking: rankingEintraege,
-        }}
-        onSaveSuccess={handleSaveSuccess}
-      />
 
       <SaveRunSuccess
         open={saveRunSuccessOpen}

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -23,7 +23,6 @@ import { saveRun } from "../api/saveRun";
 
 type Props = {
   open: boolean;
-  onClose?: () => void;
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, "tester" | "userData">;
   onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
@@ -32,7 +31,6 @@ type Props = {
 
 export const StatistikForm: React.FC<Props> = ({
   open,
-  onClose,
   tester,
   payload,
   onSaveSuccess,
@@ -91,14 +89,6 @@ export const StatistikForm: React.FC<Props> = ({
           onSubmit={handleSubmit}
           className="bg-white rounded-xl p-6 shadow-xl max-w-md w-full relative"
         >
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute top-2 right-3 text-gray-500 hover:text-black text-xl"
-            aria-label={t("close")}
-          >
-            ×
-          </button>
 
 
           <h2 className="font-bold text-lg mb-2">{t("helpImproveStats")}</h2>
@@ -151,23 +141,6 @@ export const StatistikForm: React.FC<Props> = ({
               {tester ? t("submitWithoutData") : t("saveRating")}
             </button>
           </div>
-       <div className="flex gap-3 mt-4">
-  <button
-    type="submit"
-    disabled={sending || (!tester && (!alter || !geschlecht || !branche || !berufsrolle))}
-    className="bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700 disabled:opacity-50"
-  >
-    {tester ? t("submitWithoutData") : t("saveRating")}
-  </button>
-  <button
-    type="button"
-    onClick={onClose}
-    disabled={sending}
-    className="bg-gray-200 rounded px-4 py-2"
-  >
-    {t("cancel")}
-  </button>
-</div>
 
         </form>
       </div>
@@ -229,16 +202,6 @@ export const StatistikForm: React.FC<Props> = ({
           >
             {tester ? t("submitWithoutData") : t("saveRating")}
           </button>
-          {onClose && (
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={sending}
-              className="bg-gray-200 rounded px-4 py-2"
-            >
-              {t("cancel")}
-            </button>
-          )}
         </div>
       </form>
     </div>

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -10,26 +10,18 @@ interface Props {
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, 'tester' | 'userData'>;
   onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
-  onOpenStatistikForm: (inline?: boolean) => void;
-  onCloseStatistikForm: () => void;
 }
 
 export const PersonalDataPage = ({
   tester,
   payload,
   onSaveSuccess,
-  onOpenStatistikForm,
-  onCloseStatistikForm,
 }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [formOpen, setFormOpen] = useState(true);
   const [saved, setSaved] = useState(false);
 
-  useEffect(() => {
-    onOpenStatistikForm(true);
-    return onCloseStatistikForm;
-  }, [onOpenStatistikForm, onCloseStatistikForm]);
 
   useEffect(() => {
     if (!hasSessionStarted()) {
@@ -61,7 +53,6 @@ export const PersonalDataPage = ({
             inline
             tester={tester}
             payload={payload}
-            onClose={() => setFormOpen(false)}
             onSaveSuccess={handleSaveSuccess}
           />
         </div>


### PR DESCRIPTION
## Summary
- remove `StatistikForm` overlay from `App`
- rely solely on inline version in `PersonalDataPage`
- remove any close button or cancel option from `StatistikForm`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853318df8708320a7b9a8078ee3932e