### PR TITLE
Ensure session reset on all pages

### DIFF
--- a/frontend/src/components/ResetButton.tsx
+++ b/frontend/src/components/ResetButton.tsx
@@ -12,6 +12,7 @@ export const ResetButton: React.FC = () => {
   const navigate = useNavigate();
 
   const handleClick = () => {
+    if (!window.confirm(t('resetWarning'))) return;
 
     clearSession();
 

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -37,6 +37,7 @@ const common = {
         optionDataReleaseNone: "Es werden keine Daten gespeichert",
         introText: "Mit diesem Tool können Sie Ideen bewerten und kombinieren.",
         fieldsRequired: "Bitte alle Felder ausfüllen.",
+        resetWarning: "Warnung! Durch Zur\u00fccksetzen werden alle eingegebenen Daten gel\u00f6scht. Zur\u00fccksetzen oder abbrechen?",
 
         currentIdeaCollection: "Aktuelle Ideensammlung",
         currentCombinationCollection: "Aktuelle Kombinationssammlung",
@@ -137,6 +138,7 @@ const common = {
         optionDataReleaseNone: "No data will be saved",
         introText: "This tool lets you rate and combine ideas.",
         fieldsRequired: "Please fill in all fields.",
+        resetWarning: "Warning! Resetting will remove all entered data. Reset or cancel?",
 
         currentIdeaCollection: "Current idea collection",
         currentCombinationCollection: "Current combination collection",
@@ -237,6 +239,7 @@ const common = {
         optionDataReleaseNone: "Aucune donnée ne sera enregistrée",
         introText: "Cet outil vous permet d'évaluer et de combiner des idées.",
         fieldsRequired: "Veuillez remplir tous les champs.",
+        resetWarning: "Attention! La r\u00e9initialisation supprimera toutes les donn\u00e9es saisies. R\u00e9initialiser ou annuler?",
 
         currentIdeaCollection: "Collection d'idées actuelle",
         currentCombinationCollection: "Collection de combinaisons actuelle",

--- a/frontend/src/pages/CalcResultsPage.tsx
+++ b/frontend/src/pages/CalcResultsPage.tsx
@@ -2,15 +2,14 @@ import React, { useEffect } from 'react';
 import { Ranking } from '../components/Ranking';
 import { ExportRankingButton } from '../components/ExportRankingButton';
 import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { hasSessionStarted } from '../utils/session';
+import { ResetButton } from '../components/ResetButton';
 
 interface Props {
   rankingEintraege: any[];
 }
 
 export const CalcResultsPage = ({ rankingEintraege }: Props) => {
-  const { t } = useTranslation();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -22,9 +21,7 @@ export const CalcResultsPage = ({ rankingEintraege }: Props) => {
     <div>
       <Ranking eintraege={rankingEintraege} />
       <div className="mt-6 flex justify-between items-center gap-4">
-        <button onClick={() => navigate('/')} className="px-4 py-2 bg-gray-300 rounded">
-          {t('reset')}
-        </button>
+        <ResetButton />
         <ExportRankingButton eintraege={rankingEintraege} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add confirmation dialog to `ResetButton`
- use `ResetButton` on results page
- provide translations for new popup warning

## Testing
- `./codex-setup.sh` *(fails: network access needed)*
- `pytest -q`
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853389f2d6483208125d9e64945e071