### PR TITLE
Implement Dev status tracking and validation fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import "./i18n";
 
 import { useTranslation } from "react-i18next";
 
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 
 import { StartPage } from "./pages/StartPage";
 import { SelectDataPage } from "./pages/SelectDataPage";
@@ -20,11 +20,13 @@ import { CalcResultsPage } from "./pages/CalcResultsPage";
 import { SaveRunSuccess } from "./components/SaveRunSuccess";
 import { StatusToast } from "./components/StatusToast";
 
-import { getSessionId } from "./utils/session";
+import { getSessionId, setPageStatus } from "./utils/session";
+import { devConfig } from "./devConfig";
+import { DevStatusBar } from "./components/DevStatusBar";
 
 function App() {
-	
-	const sessionId = getSessionId();
+  const location = useLocation();
+  const sessionId = getSessionId();
   const { t, i18n } = useTranslation();
   const [language, setLanguage] = useState(
     i18n.language || (import.meta.env.VITE_DEFAULT_LANGUAGE || "en"),
@@ -40,6 +42,9 @@ function App() {
   const [rankingEintraege/*, setRankingEintraege*/] = useState<any[]>([]);
   /* const [kombiInfoModalOpen, setKombiInfoModalOpen] = useState(false);
   const [kombiInfoPayload, setKombiInfoPayload] = useState<any>(null); */
+  const [dev2Mode, setDev2Mode] = useState(
+    sessionStorage.getItem('dev2mode') === 'true'
+  );
   const [saveRunSuccessOpen, setSaveRunSuccessOpen] = useState(false);
   const [saveRunMessage, setSaveRunMessage] = useState("");
   const [saveRunId, setSaveRunId] = useState<string | undefined>(undefined);
@@ -101,8 +106,8 @@ const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("default_komb
         id: row.Kombi_ID || row.id || String(idx + 1),
         name: row["#t_de#1"] || row.name || "",
         beschreibung: row["#t_de#2"] || row.beschreibung || "",
-        gewichtung: 0,
-        aktiv: false,
+        gewichtung: 3,
+        aktiv: true,
         ...row,
       }));
       setGewichtungen(parsed);
@@ -265,8 +270,20 @@ return (
   <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center pb-10">
     <header className="w-[85%] mx-auto bg-blue-300 text-white shadow-md mb-4">
       <div className="flex justify-between items-center p-3">
-        <div className="text-xs font-mono bg-blue-100 text-blue-900 px-2 py-1 rounded">
-          Session ID: {sessionId}
+        <div className="flex items-center gap-4">
+          <div className="text-xs font-mono bg-blue-100 text-blue-900 px-2 py-1 rounded">
+            Session ID: {sessionId}
+          </div>
+          {location.pathname === '/' && devConfig.dataSaveStatus === 'on' && (
+            <label className="text-xs flex items-center gap-1 text-blue-900">
+              <input
+                type="checkbox"
+                checked={dev2Mode}
+                onChange={(e) => setDev2Mode(e.target.checked)}
+              />
+              Dev2 mode
+            </label>
+          )}
         </div>
         <select
           id="lang-select"
@@ -282,9 +299,22 @@ return (
       </div>
     </header>
 
+    {dev2Mode && devConfig.dataSaveStatus === 'on' && <DevStatusBar />}
+
     <main className="flex-grow w-full">
       <Routes>
-        <Route path="/" element={<StartPage />} />
+        <Route
+          path="/"
+          element={
+            <StartPage
+              dev2Mode={dev2Mode}
+              onDev2ModeChange={setDev2Mode}
+              onStart={(v) => {
+                sessionStorage.setItem('dev2mode', v ? 'true' : 'false');
+              }}
+            />
+          }
+        />
         <Route
           path="/select-data"
           element={(

--- a/frontend/src/api/saveRun.ts
+++ b/frontend/src/api/saveRun.ts
@@ -20,7 +20,7 @@ export interface BewertungsLaufPayload {
 }
 
 export async function saveRun(
-  payload: BewertungsLaufPayload
+  payload: BewertungsLaufPayload,
 ): Promise<{ run_id?: string; message: string; error?: string }> {
   let response: Response;
   try {
@@ -35,26 +35,16 @@ export async function saveRun(
     throw new Error("Network error");
   }
 
-export async function saveRun(payload: BewertungsLaufPayload): Promise<{run_id?: string, message: string, error?: string}> {
-  const response = await fetch("/save_run", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify(payload)
-  });
-
   if (!response.ok) {
     let msg = "Unknown error";
     try {
       const err = await response.json();
-
       msg = err.error || err.detail || msg;
     } catch {
       // ignore json parse errors
     }
     throw new Error(msg);
   }
-  const data = await response.json();
-  return data;
+
+  return response.json();
 }

--- a/frontend/src/components/DevStatusBar.tsx
+++ b/frontend/src/components/DevStatusBar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { getPageStatus } from '../utils/session';
+
+const pages = ['select-data', 'idea', 'combination', 'personal', 'summary'];
+
+export const DevStatusBar: React.FC = () => {
+  const [status, setStatus] = React.useState<Record<string, string>>({});
+
+  React.useEffect(() => {
+    const update = () => setStatus(getPageStatus());
+    update();
+    window.addEventListener('pageStatusUpdated', update);
+    return () => window.removeEventListener('pageStatusUpdated', update);
+  }, []);
+
+  return (
+    <div className="bg-gray-100 border-b border-gray-300 text-xs">
+      <table className="mx-auto">
+        <thead>
+          <tr>
+            <th className="px-2">Site</th>
+            {pages.map((p) => (
+              <th key={p} className="px-2 border">
+                {p}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="px-2">Status</td>
+            {pages.map((p) => {
+              const val = status[p] || 'nok';
+              const color = val === 'ok' ? 'text-green-600' : 'text-red-600';
+              return (
+                <td key={p} className="px-2 border text-center">
+                  <span className={color}>{val}</span>
+                </td>
+              );
+            })}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+export default DevStatusBar;

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -48,7 +48,7 @@ export const StatistikForm: React.FC<Props> = ({
 
   const isValidAge = (value: string) => {
     const num = Number(value);
-    return Number.isInteger(num) && num >= 0 && num <= 120;
+    return Number.isInteger(num) && num >= 10 && num <= 120;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -122,7 +122,7 @@ export const StatistikForm: React.FC<Props> = ({
               <input
                 className="border p-2 rounded w-full"
                 type="number"
-                min="0"
+                min="10"
                 max="120"
                 placeholder={t("age")}
                 value={alter}
@@ -209,7 +209,7 @@ export const StatistikForm: React.FC<Props> = ({
             <input
               className="border p-2 rounded w-full"
               type="number"
-              min="0"
+              min="10"
               max="120"
               placeholder={t("age")}
               value={alter}

--- a/frontend/src/devConfig.ts
+++ b/frontend/src/devConfig.ts
@@ -1,0 +1,3 @@
+export const devConfig = {
+  dataSaveStatus: 'on' as 'on' | 'off',
+};

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -35,9 +35,10 @@ const common = {
         optionDataReleaseOpen: "Bitte geben Sie Ihre Daten ein (anonym)",
         optionDataReleaseAnonym: "Nur Ihr Nutzungsverhalten wird gespeichert",
         optionDataReleaseNone: "Es werden keine Daten gespeichert",
+        selectWeightsInfo: "Bitte Gewichtung der Kombinationen auswählen.",
         introText: "Mit diesem Tool können Sie Ideen bewerten und kombinieren.",
         fieldsRequired: "Bitte alle Felder ausfüllen.",
-        invalidAge: "Bitte ein realistisches Alter eingeben (0-120).",
+        invalidAge: "Bitte ein realistisches Alter eingeben (10-120).",
 
         resetWarning: "Warnung! Durch Zur\u00fccksetzen werden alle eingegebenen Daten gel\u00f6scht. Zur\u00fccksetzen oder abbrechen?",
 
@@ -138,9 +139,10 @@ const common = {
         optionDataReleaseOpen: "Please enter your data (anonymous)",
         optionDataReleaseAnonym: "Only your usage behavior will be saved",
         optionDataReleaseNone: "No data will be saved",
+        selectWeightsInfo: "Please select the weights of the combinations.",
         introText: "This tool lets you rate and combine ideas.",
         fieldsRequired: "Please fill in all fields.",
-        invalidAge: "Please enter a realistic age (0-120).",
+        invalidAge: "Please enter a realistic age (10-120).",
         resetWarning: "Warning! Resetting will remove all entered data. Reset or cancel?",
 
         currentIdeaCollection: "Current idea collection",
@@ -240,9 +242,10 @@ const common = {
         optionDataReleaseOpen: "Veuillez entrer vos données (anonymes)",
         optionDataReleaseAnonym: "Seul votre comportement d'utilisation sera enregistré",
         optionDataReleaseNone: "Aucune donnée ne sera enregistrée",
+        selectWeightsInfo: "Veuillez choisir la pondération des combinaisons.",
         introText: "Cet outil vous permet d'évaluer et de combiner des idées.",
         fieldsRequired: "Veuillez remplir tous les champs.",
-        invalidAge: "Veuillez entrer un âge réaliste (0-120).",
+        invalidAge: "Veuillez entrer un âge réaliste (10-120).",
         resetWarning: "Attention! La r\u00e9initialisation supprimera toutes les donn\u00e9es saisies. R\u00e9initialiser ou annuler?",
 
         currentIdeaCollection: "Collection d'idées actuelle",

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -4,7 +4,7 @@ import { BewertungsOptionen } from '../components/BewertungsOptionen';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
-import { hasSessionStarted, getSessionId } from '../utils/session';
+import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 
 interface Props {
@@ -51,6 +51,7 @@ export const CombinationSelectionPage = ({
                 appTester,
                 datenfreigabe,
               });
+              setPageStatus('combination', 'ok');
               navigate('/personal');
             }}
             className="px-4 py-2 bg-blue-600 text-white rounded"
@@ -69,6 +70,7 @@ export const CombinationSelectionPage = ({
           onChange={onOptionsChange}
           showDataRelease={false}
         />
+        <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
       </div>
       
     </div>

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
-import { hasSessionStarted, getSessionId } from '../utils/session';
+import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 
 interface Props {
@@ -33,6 +33,7 @@ export const ConfigSummaryPage = ({
       kombiCount,
       activeKombis,
     });
+    setPageStatus('summary', 'ok');
     navigate('/results');
   };
 

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 import { IdeenSelector } from '../components/IdeenSelector';
+import { BewertungsOptionen } from '../components/BewertungsOptionen';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
-import { hasSessionStarted, getSessionId } from '../utils/session';
+import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 
 interface Props {
@@ -35,6 +36,7 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
                 active: ideen.filter((i) => i.aktiv).map((i) => i.id),
                 inactive: ideen.filter((i) => !i.aktiv).map((i) => i.id),
               });
+              setPageStatus('idea', 'ok');
               navigate('/combinations');
             }}
             className="px-4 py-2 bg-blue-600 text-white rounded"
@@ -42,6 +44,17 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
             {t('next')}
           </button>
         </div>
+      </div>
+      <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
+        <BewertungsOptionen
+          runde1={true}
+          runde2={true}
+          appTester={false}
+          datenfreigabe="offen"
+          onChange={() => {}}
+          showDataRelease={false}
+        />
+        <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
       </div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
     </div>

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
-import { hasSessionStarted, getSessionId } from '../utils/session';
+import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 import { StatistikForm } from '../components/StatistikForm';
 import type { BewertungsLaufPayload } from '../components/StatistikForm';
@@ -34,6 +34,9 @@ export const PersonalDataPage = ({
     setSaved(true);
     setFormOpen(false);
     logEvent(getSessionId(), 'personal-data', result);
+    if (!result.error) {
+      setPageStatus('personal', 'ok');
+    }
     onSaveSuccess(result);
   };
 
@@ -44,6 +47,9 @@ export const PersonalDataPage = ({
       return;
     }
     logEvent(getSessionId(), 'personal-next', { saved });
+    if (saved || tester) {
+      setPageStatus('personal', 'ok');
+    }
     navigate('/summary');
   };
 

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -4,7 +4,7 @@ import { CollectionSelectorKombis } from '../components/CollectionSelectorKombis
 import { useNavigate } from 'react-router-dom';
 import { ResetButton } from '../components/ResetButton';
 import { useTranslation } from 'react-i18next';
-import { hasSessionStarted, getSessionId } from '../utils/session';
+import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 
 interface Props {
@@ -43,6 +43,7 @@ export const SelectDataPage = ({
                 ideenSammlung: aktuelleIdeensammlung,
                 kombiSammlung: aktuelleKombiSammlung,
               });
+              setPageStatus('select-data', 'ok');
               navigate('/ideas');
             }}
             className="px-4 py-2 bg-blue-600 text-white rounded"

--- a/frontend/src/pages/StartPage.tsx
+++ b/frontend/src/pages/StartPage.tsx
@@ -1,26 +1,44 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { markSessionStarted } from '../utils/session';
 
-export const StartPage = () => {
+interface Props {
+  dev2Mode: boolean;
+  onDev2ModeChange: (v: boolean) => void;
+  onStart: (dev2: boolean) => void;
+}
+export const StartPage = ({ dev2Mode, onDev2ModeChange, onStart }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  useEffect(() => {
+
+  const handleStart = () => {
     markSessionStarted();
-  }, []);
+    onStart(dev2Mode);
+    navigate('/select-data');
+  };
   return (
     <div className="w-[65%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 text-center min-h-[80vh]">
       <h1 className="text-4xl font-bold mb-8 text-[#1d2c5b] tracking-tight drop-shadow">
         {t('title')}
       </h1>
       <p className="mb-6 text-gray-700">{t('introText')}</p>
-      <button
-        onClick={() => navigate('/select-data')}
-        className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded"
-      >
-        {t('start')}
-      </button>
+      <div className="flex items-center justify-center gap-4 mt-4">
+        <label className="text-sm flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={dev2Mode}
+            onChange={(e) => onDev2ModeChange(e.target.checked)}
+          />
+          Dev2 mode
+        </label>
+        <button
+          onClick={handleStart}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          {t('start')}
+        </button>
+      </div>
   
     </div>
   );

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -15,6 +15,7 @@ export function resetSessionId(): string {
 }
 export function markSessionStarted() {
   sessionStorage.setItem("sessionStarted", "true");
+  resetPageStatus();
 }
 
 export function hasSessionStarted(): boolean {
@@ -24,4 +25,29 @@ export function hasSessionStarted(): boolean {
 export function clearSession() {
   sessionStorage.removeItem("sessionStarted");
   resetSessionId();
+}
+
+export function resetPageStatus() {
+  const initial = {
+    "select-data": "nok",
+    idea: "nok",
+    combination: "nok",
+    personal: "nok",
+    summary: "nok",
+  };
+  sessionStorage.setItem("pageStatus", JSON.stringify(initial));
+  window.dispatchEvent(new Event("pageStatusUpdated"));
+}
+
+export function setPageStatus(page: string, status: "ok" | "nok") {
+  const raw = sessionStorage.getItem("pageStatus");
+  const obj = raw ? JSON.parse(raw) : {};
+  obj[page] = status;
+  sessionStorage.setItem("pageStatus", JSON.stringify(obj));
+  window.dispatchEvent(new Event("pageStatusUpdated"));
+}
+
+export function getPageStatus(): Record<string, string> {
+  const raw = sessionStorage.getItem("pageStatus");
+  return raw ? JSON.parse(raw) : {};
 }


### PR DESCRIPTION
## Summary
- add optional DevStatusBar and config to enable it
- display dev2 mode checkbox on the start page header
- track page status per session via sessionStorage
- default combination weightings to neutral
- tighten age validation to 10-120
- improve error handling in saveRun API
- add evaluation options to idea page and informational text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6853da50c3548320906d0466a3a78487