### PR TITLE
Add config flag to hide round checkboxes

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -116,6 +116,8 @@ class Config:
     def api_key_required(self): return self._feature("api_key_required")
     @property
     def enable_usage_logging(self): return self._feature("enable_usage_logging")
+    @property
+    def show_round_options(self): return self._feature("show_round_options")
 
     @property
     def log_level(self):

--- a/backend/main.py
+++ b/backend/main.py
@@ -216,6 +216,14 @@ async def get_kombi_config(session: str, filename: str, lang: str = Query("de"))
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
 
+# ---- Feature-Flags für das Frontend ----
+@app.get("/api/features")
+async def get_features():
+    """Liefert Feature-Flags aus der Backend-Konfiguration."""
+    return {
+        "show_round_options": config.show_round_options,
+    }
+
 
 
 

--- a/backend/matrixconfig.ini
+++ b/backend/matrixconfig.ini
@@ -37,3 +37,4 @@ enable_debug_routes = false
 api_key_required = false
 log_level = INFO
 enable_usage_logging = true
+show_round_options = on

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ function App() {
   const [runde2, setRunde2] = useState(true);
   const [appTester, setAppTester] = useState(false);
   const [datenfreigabe, setDatenfreigabe] = useState<"offen" | "anonym" | "keine">("offen");
+  const [showRoundOptions, setShowRoundOptions] = useState(true);
   const [gewichtungen, setGewichtungen] = useState<any[]>([]);
   const [rankingEintraege/*, setRankingEintraege*/] = useState<any[]>([]);
   /* const [kombiInfoModalOpen, setKombiInfoModalOpen] = useState(false);
@@ -49,6 +50,20 @@ function App() {
 
 const [aktuelleIdeensammlung, setAktuelleIdeensammlung] = useState("default_ideen.xlsx");
 const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("default_kombi.xlsx");
+
+  // Backend-Feature-Flags laden
+  useEffect(() => {
+    fetch(`${import.meta.env.VITE_API_URL}/api/features`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (typeof data.show_round_options === "boolean") {
+          setShowRoundOptions(data.show_round_options);
+        }
+      })
+      .catch((err) => {
+        console.error("Fehler beim Laden der Features", err);
+      });
+  }, []);
 
   const fetchCollectionContent = useCallback(
     async (typ: "ideen" | "kombis", filename: string) => {
@@ -322,6 +337,7 @@ return (
                 runde2={runde2}
                 appTester={appTester}
                 datenfreigabe={datenfreigabe}
+                showRoundOptions={showRoundOptions}
                 onGewichtungenUpdate={handleGewichtungenUpdate}
                 onOptionsChange={handleBewertungsOptionenChange}
               />

--- a/frontend/src/components/BewertungsOptionen.tsx
+++ b/frontend/src/components/BewertungsOptionen.tsx
@@ -8,6 +8,7 @@ type BewertungsOptionenProps = {
   datenfreigabe: "offen" | "anonym" | "keine";
   onChange: (field: string, value: any) => void;
   showDataRelease?: boolean;
+  showRoundOptions?: boolean;
 };
 
 export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
@@ -17,6 +18,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
   datenfreigabe,
   onChange,
   showDataRelease = true,
+  showRoundOptions = true,
 }) => {
   const { t } = useTranslation();
 
@@ -26,25 +28,29 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
 
       {/* Checkboxen nebeneinander und zentriert */}
       <div className="flex justify-center gap-8 flex-wrap text-center">
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={runde1}
-            onChange={(e) => onChange("runde1", e.target.checked)}
-            className="accent-[#1d2c5b]"
-          />
-          {t("optionConsiderRound1")}
-        </label>
+        {showRoundOptions && (
+          <>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={runde1}
+                onChange={(e) => onChange("runde1", e.target.checked)}
+                className="accent-[#1d2c5b]"
+              />
+              {t("optionConsiderRound1")}
+            </label>
 
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={runde2}
-            onChange={(e) => onChange("runde2", e.target.checked)}
-            className="accent-[#1d2c5b]"
-          />
-          {t("optionConsiderRound2")}
-        </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={runde2}
+                onChange={(e) => onChange("runde2", e.target.checked)}
+                className="accent-[#1d2c5b]"
+              />
+              {t("optionConsiderRound2")}
+            </label>
+          </>
+        )}
 
         <label className="flex items-center gap-2">
           <input

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -13,6 +13,7 @@ interface Props {
   runde2: boolean;
   appTester: boolean;
   datenfreigabe: 'offen' | 'anonym' | 'keine';
+  showRoundOptions?: boolean;
   onGewichtungenUpdate: (g: any[]) => void;
   onOptionsChange: (field: string, value: any) => void;
 }
@@ -23,6 +24,7 @@ export const CombinationSelectionPage = ({
   runde2,
   appTester,
   datenfreigabe,
+  showRoundOptions = true,
   onGewichtungenUpdate,
   onOptionsChange,
 }: Props) => {
@@ -68,6 +70,7 @@ export const CombinationSelectionPage = ({
           datenfreigabe={datenfreigabe}
           onChange={onOptionsChange}
           showDataRelease={false}
+          showRoundOptions={showRoundOptions}
         />
       </div>
       

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -16,6 +16,7 @@ interface Props {
   onIdeenUpdate: (ideen: any[]) => void;
   onBewertungsOptionenChange: (field: string, value: any) => void;
   onGewichtungenUpdate: (g: any[]) => void;
+  showRoundOptions?: boolean;
   onOpenStatistikForm?: (inline?: boolean) => void;
 }
 
@@ -30,6 +31,7 @@ export const ConfigPage = ({
   onIdeenUpdate,
   onBewertungsOptionenChange,
   onGewichtungenUpdate,
+  showRoundOptions = true,
   onOpenStatistikForm = () => {},
 }: Props) => {
   const { t } = useTranslation();
@@ -44,6 +46,7 @@ export const ConfigPage = ({
           appTester={appTester}
           datenfreigabe={datenfreigabe}
           onChange={onBewertungsOptionenChange}
+          showRoundOptions={showRoundOptions}
         />
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />


### PR DESCRIPTION
## Summary
- enable config `show_round_options` to toggle consideration checkboxes
- serve flag via new `/api/features` route
- consume flag in the React frontend to hide "Consider round 1/2"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853daf45f248320a68ce2add988027a