### PR TITLE
Fix flicker on idea page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,6 +96,8 @@ const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("default_komb
 
   const loadIdeen = useCallback(
     async (filename: string) => {
+      // Clear previous ideas to avoid flicker while loading new data
+      setIdeen([]);
       const data = await fetchCollectionContent("ideen", filename);
       if (!data) return;
       const rows = Array.isArray(data.rows) ? data.rows : [];

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -28,6 +28,7 @@ const common = {
         noDetails: "Keine Details vorhanden",
 
         optionsTitle: "Bewertungsoptionen",
+        ideaSelectionTitle: "Ideenauswahl",
         optionConsiderRound1: "Runde 1 berücksichtigen",
         optionConsiderRound2: "Runde 2 berücksichtigen",
         optionAppTester: "App-Tester (kein Logging, keine Datenabfrage)",
@@ -132,6 +133,7 @@ const common = {
         noDetails: "No details available",
 
         optionsTitle: "Evaluation options",
+        ideaSelectionTitle: "Idea selection",
         optionConsiderRound1: "Consider round 1",
         optionConsiderRound2: "Consider round 2",
         optionAppTester: "App tester (no logging, no data collection)",
@@ -235,6 +237,7 @@ const common = {
         noDetails: "Aucun détail disponible",
 
         optionsTitle: "Options d'évaluation",
+        ideaSelectionTitle: "Sélection d'idées",
         optionConsiderRound1: "Prenez en compte le tour 1",
         optionConsiderRound2: "Prenez en compte le tour 2",
         optionAppTester: "Testeur d'app (pas de journalisation, pas de collecte de données)",

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { IdeenSelector } from '../components/IdeenSelector';
-import { BewertungsOptionen } from '../components/BewertungsOptionen';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
@@ -46,14 +45,7 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
         </div>
       </div>
       <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
-        <BewertungsOptionen
-          runde1={true}
-          runde2={true}
-          appTester={false}
-          datenfreigabe="offen"
-          onChange={() => {}}
-          showDataRelease={false}
-        />
+        <h2 className="text-lg font-semibold text-center">{t('ideaSelectionTitle')}</h2>
         <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
       </div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />


### PR DESCRIPTION
## Summary
- clear old ideas while loading new data to avoid flicker
- remove evaluation options from idea page and display a custom title
- add translations for the new title in all languages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6853df1b89bc8320a77c7f223fc52e7b