### PR TITLE
Fix layout of combination page

### DIFF
--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -62,7 +62,6 @@ export const CombinationSelectionPage = ({
           </button>
         </div>
       </div>
-      <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
         <BewertungsOptionen
           runde1={runde1}
@@ -75,6 +74,7 @@ export const CombinationSelectionPage = ({
         />
         <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
       </div>
+      <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       
     </div>
   );


### PR DESCRIPTION
## Summary
- move the evaluation options container above the list of combinations on `/combinations`

## Testing
- `npm run lint` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6853df7bb32c83209b711426b2dcb831