### PR TITLE
Fix dropdown crash when starting app

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,10 +139,13 @@ const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("default_komb
     i18n.changeLanguage(lang);
   };
 
-  const handleIdeenSammlungChange = (dateiName: string) => {
-    setAktuelleIdeensammlung(dateiName);
-    loadIdeen(dateiName);
-  };
+  const handleIdeenSammlungChange = useCallback(
+    (dateiName: string) => {
+      setAktuelleIdeensammlung(dateiName);
+      loadIdeen(dateiName);
+    },
+    [loadIdeen],
+  );
 const handleKombiUpload = async (file: File, sessionId: string) => {
   setStatusToastMessage(t("uploadFile") + " " + file.name + " (Session: " + sessionId + ")");
   setStatusToastType("info");
@@ -176,10 +179,13 @@ const handleKombiUpload = async (file: File, sessionId: string) => {
   }
 };
 
-const handleKombiSammlungChange = (dateiName: string) => {
-  setAktuelleKombiSammlung(dateiName);
-  loadKombis(dateiName);
-};
+const handleKombiSammlungChange = useCallback(
+  (dateiName: string) => {
+    setAktuelleKombiSammlung(dateiName);
+    loadKombis(dateiName);
+  },
+  [loadKombis],
+);
 
   // Nach Auswahl oder Upload einer Kombi-Datei Konfiguration laden
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stabilize callbacks for changing idea/combination collections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6853eceda7848320be7ea20050741945