### PR TITLE
Fix save run endpoint usage and update docs

### DIFF
--- a/ARCHITEKTUR.md
+++ b/ARCHITEKTUR.md
@@ -231,7 +231,7 @@ README_DE.md/README_EN.md ← Kurzbeschreibung, Nutzungshinweise
   - `backend_logging = on/off`
   - `standardeinstellung_runde1 = einbezogen/ausgeschlossen`
   - `exportformat = csv/pdf/excel`
-*Letzte Aktualisierung durch ChatGPT: (18.06.2025:23:25)*
+*Letzte Aktualisierung durch ChatGPT: (19.06.2025:11:16)*
 
 ### 3. **Bewertungslogik**
 - Bewertet alle aktiven Ideen mit den aktiven Kombinationen
@@ -245,6 +245,8 @@ README_DE.md/README_EN.md ← Kurzbeschreibung, Nutzungshinweise
 - Wenn `App-Tester` aktiv → kein Logging
 - Wenn `datapopup = on` → anonyme Datenabfrage vor Berechnung
 - Zusätzlich protokolliert `/log_step` jeden Schritt einer Session im Ordner `archive/`
+- Die Route `/save_run` legt das Ergebnis einer Bewertung als JSON-Datei ab.
+- Beide Endpoints werden im Frontend über `VITE_API_URL` aufgerufen.
 
 ---
 
@@ -299,4 +301,4 @@ Alle Dateien befinden sich unter:
 
 ---
 
-*Letzte Aktualisierung durch ChatGPT: (18.06.2025:23:25)*
+*Letzte Aktualisierung durch ChatGPT: (19.06.2025:11:16)*

--- a/DOKUMENTATION.md
+++ b/DOKUMENTATION.md
@@ -51,6 +51,8 @@ Neu hinzugekommen sind:
 - Reset-Buttons zeigen nun eine Warnung und starten garantiert eine neue Session.
 - Auf der "Select Data" Seite gibt es keinen Zurück-Button mehr.
 - Fehlermeldungen vom Backend werden beim Speichern von Bewertungen angezeigt.
+- API-Aufrufe zu `/save_run` und `/log_step` nutzen nun `VITE_API_URL`, wodurch
+  der Fehler "unknown error" auf der Personal-Seite behoben wurde.
 
 ### Nächste Schritte
 - Navigationsmenü (Arbeitsplan Punkt 4) ergänzen und 404-Seite erstellen.
@@ -82,4 +84,4 @@ Dann kannst du sofort am nächsten Schritt weiterarbeiten.
 
 ---
 
-*Letzte Aktualisierung durch ChatGPT: (18.06.2025:23:25)*
+*Letzte Aktualisierung durch ChatGPT: (19.06.2025:11:16)*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ cd frontend
 npm run dev
 ```
 
+The frontend expects the backend URL in the `VITE_API_URL` environment
+variable.  You can adjust this in `frontend/.env` if your backend is not
+running on `http://localhost:8000`.
+
 The i18next library's debug output is disabled by default. You can enable it by
 setting the `VITE_I18N_DEBUG` environment variable to `true` before starting the
 frontend:

--- a/frontend/src/api/logEvent.ts
+++ b/frontend/src/api/logEvent.ts
@@ -1,5 +1,6 @@
 export async function logEvent(session: string, step: string, data: any) {
-  await fetch('/log_step', {
+  const apiBase = import.meta.env.VITE_API_URL;
+  await fetch(`${apiBase}/log_step`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session, step, data })

--- a/frontend/src/api/saveRun.ts
+++ b/frontend/src/api/saveRun.ts
@@ -22,9 +22,10 @@ export interface BewertungsLaufPayload {
 export async function saveRun(
   payload: BewertungsLaufPayload,
 ): Promise<{ run_id?: string; message: string; error?: string }> {
+  const apiBase = import.meta.env.VITE_API_URL;
   let response: Response;
   try {
-    response = await fetch("/save_run", {
+    response = await fetch(`${apiBase}/save_run`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
     '/session_files': 'http://localhost:8000',
     '/upload': 'http://localhost:8000',
     '/api': 'http://localhost:8000',
-	 '/download_template': 'http://localhost:8000', // ergänzen!
+    '/download_template': 'http://localhost:8000',
+    '/save_run': 'http://localhost:8000',
+    '/log_step': 'http://localhost:8000',
   }}
 });


### PR DESCRIPTION
## Summary
- use `VITE_API_URL` for `saveRun` and `logEvent` API calls
- expose `/save_run` and `/log_step` through Vite dev proxy
- document backend URL usage in README
- update project documentation and architecture notes

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6853f103893c8320a71f882f8efb7b9e