### PR TITLE
Ensure reset clears frontend state

### DIFF
--- a/frontend/src/components/ResetButton.tsx
+++ b/frontend/src/components/ResetButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { clearSession } from '../utils/session';
@@ -9,7 +8,6 @@ import { resetSessionId } from '../utils/session';
 
 export const ResetButton: React.FC = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   const handleClick = () => {
     if (!window.confirm(t('resetWarning'))) return;
@@ -18,7 +16,7 @@ export const ResetButton: React.FC = () => {
 
     resetSessionId();
 
-    navigate('/');
+    window.location.href = '/';
   };
 
   return (


### PR DESCRIPTION
## Summary
- reload the page when resetting the session so UI state returns to defaults

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853f3af725483208095824f5af80239