### PR TITLE
Fix personal page backend status and add debugging

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -312,7 +312,7 @@ async def save_run(data: dict):
         raise HTTPException(status_code=400, detail="Ung\u00fcltige Daten")
 
     if data.get("tester"):
-        return {"message": "Tester-Modus: Bewertungslauf NICHT gespeichert."}
+        return {"message": "Tester-Modus: Bewertungslauf NICHT gespeichert.", "status": "ok"}
 
     run_id = str(uuid.uuid4())
     filepath = STORAGE_FOLDER / f"{run_id}.json"
@@ -320,7 +320,7 @@ async def save_run(data: dict):
     with open(filepath, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
-    return {"message": "Bewertungslauf gespeichert", "run_id": run_id}
+    return {"message": "Bewertungslauf gespeichert", "run_id": run_id, "status": "ok"}
 
 
 # ---- Nutzungsdaten speichern ----

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { SelectDataPage } from "./pages/SelectDataPage";
 import { IdeaSelectionPage } from "./pages/IdeaSelectionPage";
 import { CombinationSelectionPage } from "./pages/CombinationSelectionPage";
 import { PersonalDataPage } from "./pages/PersonalDataPage";
+import type { SaveRunResponse } from "./components/StatistikForm";
 import { ConfigSummaryPage } from "./pages/ConfigSummaryPage";
 import { CalcResultsPage } from "./pages/CalcResultsPage";
 
@@ -273,7 +274,7 @@ const handleKombiSammlungChange = useCallback(
   };
 
 
-  const handleSaveSuccess = (result: { run_id?: string; message: string }) => {
+  const handleSaveSuccess = (result: SaveRunResponse) => {
     setSaveRunId(result.run_id);
     setSaveRunMessage(result.message);
     setSaveRunSuccessOpen(true);

--- a/frontend/src/api/saveRun.ts
+++ b/frontend/src/api/saveRun.ts
@@ -19,9 +19,16 @@ export interface BewertungsLaufPayload {
   // ...weitere gewünschte Felder
 }
 
+export interface SaveRunResponse {
+  run_id?: string;
+  message: string;
+  status?: string;
+  error?: string;
+}
+
 export async function saveRun(
   payload: BewertungsLaufPayload,
-): Promise<{ run_id?: string; message: string; error?: string }> {
+): Promise<SaveRunResponse> {
   const apiBase = import.meta.env.VITE_API_URL;
   let response: Response;
   try {

--- a/frontend/src/components/DevStatusBar.tsx
+++ b/frontend/src/components/DevStatusBar.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
-import { getPageStatus } from '../utils/session';
+import { getPageStatus, getSaveRunStatus } from '../utils/session';
 
 const pages = ['select-data', 'idea', 'combination', 'personal', 'summary'];
 
 export const DevStatusBar: React.FC = () => {
   const [status, setStatus] = React.useState<Record<string, string>>({});
+  const [saveStatus, setSaveStatus] = React.useState(getSaveRunStatus());
 
   React.useEffect(() => {
-    const update = () => setStatus(getPageStatus());
-    update();
-    window.addEventListener('pageStatusUpdated', update);
-    return () => window.removeEventListener('pageStatusUpdated', update);
+    const updateStatus = () => setStatus(getPageStatus());
+    const updateSave = () => setSaveStatus(getSaveRunStatus());
+    updateStatus();
+    updateSave();
+    window.addEventListener('pageStatusUpdated', updateStatus);
+    window.addEventListener('saveRunStatusUpdated', updateSave);
+    return () => {
+      window.removeEventListener('pageStatusUpdated', updateStatus);
+      window.removeEventListener('saveRunStatusUpdated', updateSave);
+    };
   }, []);
 
   return (
@@ -38,6 +45,12 @@ export const DevStatusBar: React.FC = () => {
                 </td>
               );
             })}
+          </tr>
+          <tr>
+            <td className="px-2">SaveRun</td>
+            <td colSpan={pages.length} className="px-2 border text-center">
+              <span>{saveStatus}</span>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { saveRun } from "../api/saveRun";
+import { saveRun, SaveRunResponse } from "../api/saveRun";
+import { setSaveRunStatus } from "../utils/session";
+import { useEffect } from "react";
 
 export interface BewertungsLaufPayload {
   tester: boolean;
@@ -24,7 +26,7 @@ type Props = {
   open: boolean;
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, "tester" | "userData">;
-  onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
+  onSaveSuccess: (result: SaveRunResponse) => void;
   onClose?: () => void;    // <---- Das ergänzt!
   inline?: boolean;
 };
@@ -38,6 +40,9 @@ export const StatistikForm: React.FC<Props> = ({
   inline = false,
 }) => {
   const { t } = useTranslation();
+  useEffect(() => {
+    setSaveRunStatus('idle');
+  }, []);
 
   const [alter, setAlter] = useState("");
   const [geschlecht, setGeschlecht] = useState("");
@@ -55,6 +60,7 @@ export const StatistikForm: React.FC<Props> = ({
     e.preventDefault();
     setSending(true);
     setFehler(null);
+    setSaveRunStatus('sending');
 
     if (!tester && (!alter || !geschlecht || !branche || !berufsrolle)) {
       setFehler(t('fieldsRequired'));
@@ -84,9 +90,11 @@ export const StatistikForm: React.FC<Props> = ({
     try {
       const result = await saveRun(fullPayload);
       onSaveSuccess(result);
+      setSaveRunStatus('ok');
       if (onClose) onClose();    // <--- Callback nach Erfolg, falls übergeben
     } catch (e: any) {
       setFehler(e.message || t("submitError"));
+      setSaveRunStatus('error');
     } finally {
       setSending(false);
     }
@@ -128,13 +136,16 @@ export const StatistikForm: React.FC<Props> = ({
                 value={alter}
                 onChange={(e) => setAlter(e.target.value)}
               />
-              <input
+              <select
                 className="border p-2 rounded w-full"
-                type="text"
-                placeholder={t("gender")}
                 value={geschlecht}
                 onChange={(e) => setGeschlecht(e.target.value)}
-              />
+              >
+                <option value="">{t("gender")}</option>
+                <option value="male">Männlich</option>
+                <option value="female">Weiblich</option>
+                <option value="none">Keine Angabe</option>
+              </select>
               <input
                 className="border p-2 rounded w-full"
                 type="text"
@@ -215,13 +226,16 @@ export const StatistikForm: React.FC<Props> = ({
               value={alter}
               onChange={(e) => setAlter(e.target.value)}
             />
-            <input
+            <select
               className="border p-2 rounded w-full"
-              type="text"
-              placeholder={t("gender")}
               value={geschlecht}
               onChange={(e) => setGeschlecht(e.target.value)}
-            />
+            >
+              <option value="">{t("gender")}</option>
+              <option value="male">Männlich</option>
+              <option value="female">Weiblich</option>
+              <option value="none">Keine Angabe</option>
+            </select>
             <input
               className="border p-2 rounded w-full"
               type="text"
@@ -270,3 +284,4 @@ export const StatistikForm: React.FC<Props> = ({
 };
 
 // KEIN weiteres export default – das ist hier nicht mehr nötig!
+export type { SaveRunResponse };

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -5,12 +5,12 @@ import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 import { StatistikForm } from '../components/StatistikForm';
-import type { BewertungsLaufPayload } from '../components/StatistikForm';
+import type { BewertungsLaufPayload, SaveRunResponse } from '../components/StatistikForm';
 
 interface Props {
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, 'tester' | 'userData'>;
-  onSaveSuccess: (result: { run_id?: string; message: string; error?: string }) => void;
+  onSaveSuccess: (result: SaveRunResponse) => void;
 }
 
 export const PersonalDataPage = ({
@@ -30,11 +30,11 @@ export const PersonalDataPage = ({
     }
   }, [navigate]);
 
-  const handleSaveSuccess = (result: { run_id?: string; message: string; error?: string }) => {
+  const handleSaveSuccess = (result: SaveRunResponse) => {
     setSaved(true);
     setFormOpen(false);
     logEvent(getSessionId(), 'personal-data', result);
-    if (!result.error) {
+    if (!result.error && result.status === 'ok') {
       setPageStatus('personal', 'ok');
     }
     onSaveSuccess(result);

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -51,3 +51,16 @@ export function getPageStatus(): Record<string, string> {
   const raw = sessionStorage.getItem("pageStatus");
   return raw ? JSON.parse(raw) : {};
 }
+
+// ---- Backend Save Status Handling ----
+export type SaveRunStatus = 'idle' | 'sending' | 'ok' | 'error';
+
+export function setSaveRunStatus(status: SaveRunStatus) {
+  sessionStorage.setItem('saveRunStatus', status);
+  window.dispatchEvent(new Event('saveRunStatusUpdated'));
+}
+
+export function getSaveRunStatus(): SaveRunStatus {
+  return (sessionStorage.getItem('saveRunStatus') as SaveRunStatus) || 'idle';
+}
+


### PR DESCRIPTION
## Summary
- add `status: ok` to backend `/save_run` response
- show backend save status in the developer status bar
- track save status in session utilities
- update statistic form to use dropdown gender field and track save status
- adapt personal page and app types for new SaveRunResponse

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853f435d298832081fb2dab75d1a16d