### PR TITLE
Add configurable loading screen in summary

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -143,6 +143,10 @@ class Config:
     def supported_languages(self):
         raw = self.config["Features"].get("available_languages", "de,en,fr")
         return [lang.strip() for lang in raw.split(",")]
+
+    @property
+    def duration_loadingscreen(self):
+        return float(self.config["Features"].get("duration_loadingscreen", 0.8))
     @property
     def valid_ideen_template(self):
         path = self.config["Dateien"].get("valid_ideen_template", None)

--- a/backend/main.py
+++ b/backend/main.py
@@ -222,6 +222,7 @@ async def get_features():
     """Liefert Feature-Flags aus der Backend-Konfiguration."""
     return {
         "show_round_options": config.show_round_options,
+        "loadingscreen_duration": config.duration_loadingscreen,
     }
 
 

--- a/backend/matrixconfig.ini
+++ b/backend/matrixconfig.ini
@@ -38,3 +38,4 @@ api_key_required = false
 log_level = INFO
 enable_usage_logging = true
 show_round_options = on
+duration_loadingscreen = 0.8

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
   const [appTester, setAppTester] = useState(false);
   const [datenfreigabe, setDatenfreigabe] = useState<"offen" | "anonym" | "keine">("offen");
   const [showRoundOptions, setShowRoundOptions] = useState(true);
+  const [loadingScreenDuration, setLoadingScreenDuration] = useState(0.8);
   const [gewichtungen, setGewichtungen] = useState<any[]>([]);
   const [rankingEintraege/*, setRankingEintraege*/] = useState<any[]>([]);
   /* const [kombiInfoModalOpen, setKombiInfoModalOpen] = useState(false);
@@ -63,6 +64,9 @@ const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("default_komb
       .then((data) => {
         if (typeof data.show_round_options === "boolean") {
           setShowRoundOptions(data.show_round_options);
+        }
+        if (typeof data.loadingscreen_duration === "number") {
+          setLoadingScreenDuration(data.loadingscreen_duration);
         }
       })
       .catch((err) => {
@@ -410,6 +414,7 @@ return (
                 activeIdeen={ideen.filter((i) => i.aktiv).length}
                 kombiCount={gewichtungen.length}
                 activeKombis={gewichtungen.filter((k) => k.aktiv).length}
+                loadingDuration={loadingScreenDuration}
               />
             </div>
           )}

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -102,6 +102,8 @@ const common = {
         uploadSuccess: "Upload erfolgreich",
         loadError: "Laden fehlgeschlagen",
         noDataLoaded: "Keine Daten geladen",
+        calculating: "Berechnung läuft...",
+        showResults: "Ergebnis anzeigen",
       },
     },
     en: {
@@ -206,6 +208,8 @@ const common = {
         uploadSuccess: "Upload successful",
         loadError: "Loading failed",
         noDataLoaded: "No data loaded",
+        calculating: "Calculating...",
+        showResults: "Show results",
       },
     },
     fr: {
@@ -312,6 +316,8 @@ const common = {
         uploadSuccess: "Téléversement réussi",
         loadError: "Échec du chargement",
         noDataLoaded: "Aucune donnée chargée",
+        calculating: "Calcul en cours...",
+        showResults: "Afficher le résultat",
       },
     },
   };

--- a/frontend/src/pages/ConfigSummaryPage.tsx
+++ b/frontend/src/pages/ConfigSummaryPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
@@ -10,6 +10,7 @@ interface Props {
   activeIdeen: number;
   kombiCount: number;
   activeKombis: number;
+  loadingDuration: number;
 }
 
 export const ConfigSummaryPage = ({
@@ -17,10 +18,15 @@ export const ConfigSummaryPage = ({
   activeIdeen,
   kombiCount,
   activeKombis,
+  loadingDuration,
 }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const disabled = activeIdeen === 0 || activeKombis === 0;
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [progressDuration, setProgressDuration] = useState(0);
+  const [showResultButton, setShowResultButton] = useState(false);
 
   const handleCalculate = () => {
     if (disabled) {
@@ -34,7 +40,16 @@ export const ConfigSummaryPage = ({
       activeKombis,
     });
     setPageStatus('summary', 'ok');
-    navigate('/results');
+    const duration = loadingDuration + Math.random() * 0.4;
+    setProgressDuration(duration);
+    setLoading(true);
+    setShowResultButton(false);
+    setProgress(0);
+    setTimeout(() => setProgress(100), 50);
+    setTimeout(() => {
+      setLoading(false);
+      setShowResultButton(true);
+    }, duration * 1000);
   };
 
   useEffect(() => {
@@ -72,7 +87,28 @@ export const ConfigSummaryPage = ({
           {t('currentCombinationCollection')}: {activeKombis} / {kombiCount}
         </li>
       </ul>
-      
+      {loading && (
+        <div className="my-4">
+          <p className="mb-2">{t('calculating')}</p>
+          <div className="w-full bg-gray-200 rounded">
+            <div
+              className="h-2 bg-blue-600 rounded transition-all"
+              style={{ width: `${progress}%`, transitionDuration: `${progressDuration}s` }}
+            />
+          </div>
+        </div>
+      )}
+      {showResultButton && (
+        <div className="mt-4">
+          <button
+            onClick={() => navigate('/results')}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            {t('showResults')}
+          </button>
+        </div>
+      )}
+
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- configure duration of loading screen via `duration_loadingscreen` in `matrixconfig.ini`
- expose new configuration through backend
- fetch `loadingscreen_duration` in frontend
- show loading progress bar before navigating to results
- provide translations for new UI texts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `find backend -name "*.py" | xargs -I {} python -m py_compile {}`

------
https://chatgpt.com/codex/tasks/task_e_6853f2ce90988320a3ce28250a0e6a47