### PR TITLE
Fix SaveRunResponse re-export

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ import { SelectDataPage } from "./pages/SelectDataPage";
 import { IdeaSelectionPage } from "./pages/IdeaSelectionPage";
 import { CombinationSelectionPage } from "./pages/CombinationSelectionPage";
 import { PersonalDataPage } from "./pages/PersonalDataPage";
-import type { SaveRunResponse } from "./components/StatistikForm";
+import type { SaveRunResponse } from "./api/saveRun";
 import { ConfigSummaryPage } from "./pages/ConfigSummaryPage";
 import { CalcResultsPage } from "./pages/CalcResultsPage";
 

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -282,5 +282,3 @@ export const StatistikForm: React.FC<Props> = ({
     </div>
   );
 };
-
-export type { SaveRunResponse };

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -5,7 +5,8 @@ import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 import { StatistikForm } from '../components/StatistikForm';
-import type { BewertungsLaufPayload, SaveRunResponse } from '../components/StatistikForm';
+import type { BewertungsLaufPayload } from '../components/StatistikForm';
+import type { SaveRunResponse } from '../api/saveRun';
 
 interface Props {
   tester: boolean;


### PR DESCRIPTION
## Summary
- remove unnecessary SaveRunResponse re-export from StatistikForm
- use SaveRunResponse directly from `api/saveRun` in App and PersonalDataPage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6853fb0911288320ae1f3fcdd83cafa5