### PR TITLE
Remove duplicate export

### DIFF
--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -299,4 +299,4 @@ export const StatistikForm: React.FC<Props> = ({
   );
 };
 
-export type { SaveRunResponse, UserData };
+export type { SaveRunResponse };


### PR DESCRIPTION
## Summary
- remove duplicate `UserData` export from StatistikForm

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853fd66117c83208f58ef185bb61b84