### PR TITLE
Fix StatistikForm compile error

### DIFF
--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -4,26 +4,6 @@ import { saveRun } from "../api/saveRun";
 import type { SaveRunResponse, BewertungsLaufPayload, UserData } from "../api/saveRun";
 import { setSaveRunStatus } from "../utils/session";
 
-
-export interface UserData {
-  alter?: string;
-  geschlecht?: string;
-  branche?: string;
-  berufsrolle?: string;
-}
-
-export interface BewertungsLaufPayload {
-  tester: boolean;
-  userData?: UserData;
-  ideenSammlung: string;
-  kombiSammlung: string;
-  gewaehlteIdeen: string[];
-  deaktivierteIdeen: string[];
-  gewichtungen: Record<string, number>;
-  ergebnisRanking: any[];
-  zeitstempel?: string;
-}
-
 type Props = {
   open: boolean;
   tester: boolean;
@@ -299,8 +279,4 @@ export const StatistikForm: React.FC<Props> = ({
     </div>
   );
 };
-
-
-// Nur SaveRunResponse exportieren, nicht UserData (wird oben per `export interface` bereits exportiert)
-export type { SaveRunResponse };
 


### PR DESCRIPTION
## Summary
- remove duplicate interface declarations from `StatistikForm.tsx`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing React type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685402dd6314832092e5cb9c88b1398b