### PR TITLE
Fix TS import conflict

### DIFF
--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { saveRun } from "../api/saveRun";
-import type { SaveRunResponse, BewertungsLaufPayload, UserData } from "../api/saveRun";
+import {
+  saveRun,
+  type SaveRunResponse,
+  type BewertungsLaufPayload,
+  type UserData,
+} from "../api/saveRun";
 import { setSaveRunStatus } from "../utils/session";
 
 type Props = {


### PR DESCRIPTION
## Summary
- unify runtime and type imports for `saveRun`

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68540656ac948320bd41ef14d915b801