### PR TITLE
Enhance personal data options

### DIFF
--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -30,9 +30,27 @@ export const StatistikForm: React.FC<Props> = ({
     setSaveRunStatus("idle");
   }, []);
 
+  const industryOptions = [
+    "Baugewerbe",
+    "Energie",
+    "IT",
+    "Bildung",
+    "Gesundheit",
+  ];
+
+  const jobRoleOptions = [
+    "Ingenieur/in",
+    "Architekt/in",
+    "Manager/in",
+    "Forscher/in",
+    "Student/in",
+  ];
+
   const [alter, setAlter] = useState("");
   const [geschlecht, setGeschlecht] = useState("");
+  const [brancheOption, setBrancheOption] = useState("");
   const [branche, setBranche] = useState("");
+  const [berufsrolleOption, setBerufsrolleOption] = useState("");
   const [berufsrolle, setBerufsrolle] = useState("");
   const [sending, setSending] = useState(false);
   const [fehler, setFehler] = useState<string | null>(null);
@@ -137,20 +155,66 @@ export const StatistikForm: React.FC<Props> = ({
                 <option value="female">{t("genderFemale")}</option>
                 <option value="none">{t("genderNone")}</option>
               </select>
-              <input
+              <select
                 className="border p-2 rounded w-full"
-                type="text"
-                placeholder={t("industry")}
-                value={branche}
-                onChange={(e) => setBranche(e.target.value)}
-              />
-              <input
+                value={brancheOption}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setBrancheOption(val);
+                  if (val !== "other") {
+                    setBranche(val);
+                  } else {
+                    setBranche("");
+                  }
+                }}
+              >
+                <option value="">{t("industry")}</option>
+                {industryOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+                <option value="other">{t("other")}</option>
+              </select>
+              {brancheOption === "other" && (
+                <input
+                  className="border p-2 rounded w-full"
+                  type="text"
+                  placeholder={t("industry")}
+                  value={branche}
+                  onChange={(e) => setBranche(e.target.value)}
+                />
+              )}
+              <select
                 className="border p-2 rounded w-full"
-                type="text"
-                placeholder={t("jobRole")}
-                value={berufsrolle}
-                onChange={(e) => setBerufsrolle(e.target.value)}
-              />
+                value={berufsrolleOption}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setBerufsrolleOption(val);
+                  if (val !== "other") {
+                    setBerufsrolle(val);
+                  } else {
+                    setBerufsrolle("");
+                  }
+                }}
+              >
+                <option value="">{t("jobRole")}</option>
+                {jobRoleOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+                <option value="other">{t("other")}</option>
+              </select>
+              {berufsrolleOption === "other" && (
+                <input
+                  className="border p-2 rounded w-full"
+                  type="text"
+                  placeholder={t("jobRole")}
+                  value={berufsrolle}
+                  onChange={(e) => setBerufsrolle(e.target.value)}
+                />
+              )}
             </div>
           )}
 
@@ -231,20 +295,66 @@ export const StatistikForm: React.FC<Props> = ({
               <option value="female">{t("genderFemale")}</option>
               <option value="none">{t("genderNone")}</option>
             </select>
-            <input
+            <select
               className="border p-2 rounded w-full"
-              type="text"
-              placeholder={t("industry")}
-              value={branche}
-              onChange={(e) => setBranche(e.target.value)}
-            />
-            <input
+              value={brancheOption}
+              onChange={(e) => {
+                const val = e.target.value;
+                setBrancheOption(val);
+                if (val !== "other") {
+                  setBranche(val);
+                } else {
+                  setBranche("");
+                }
+              }}
+            >
+              <option value="">{t("industry")}</option>
+              {industryOptions.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+              <option value="other">{t("other")}</option>
+            </select>
+            {brancheOption === "other" && (
+              <input
+                className="border p-2 rounded w-full"
+                type="text"
+                placeholder={t("industry")}
+                value={branche}
+                onChange={(e) => setBranche(e.target.value)}
+              />
+            )}
+            <select
               className="border p-2 rounded w-full"
-              type="text"
-              placeholder={t("jobRole")}
-              value={berufsrolle}
-              onChange={(e) => setBerufsrolle(e.target.value)}
-            />
+              value={berufsrolleOption}
+              onChange={(e) => {
+                const val = e.target.value;
+                setBerufsrolleOption(val);
+                if (val !== "other") {
+                  setBerufsrolle(val);
+                } else {
+                  setBerufsrolle("");
+                }
+              }}
+            >
+              <option value="">{t("jobRole")}</option>
+              {jobRoleOptions.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+              <option value="other">{t("other")}</option>
+            </select>
+            {berufsrolleOption === "other" && (
+              <input
+                className="border p-2 rounded w-full"
+                type="text"
+                placeholder={t("jobRole")}
+                value={berufsrolle}
+                onChange={(e) => setBerufsrolle(e.target.value)}
+              />
+            )}
           </div>
         )}
 

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -29,6 +29,7 @@ const common = {
 
         optionsTitle: "Bewertungsoptionen",
         ideaSelectionTitle: "Ideenauswahl",
+        selectIdeasInfo: "Hier k\u00f6nnen Sie Ideen f\u00fcr die Berechnung aktivieren oder deaktivieren.",
         optionConsiderRound1: "Runde 1 berücksichtigen",
         optionConsiderRound2: "Runde 2 berücksichtigen",
         optionAppTester: "App-Tester (kein Logging, keine Datenabfrage)",
@@ -82,6 +83,7 @@ const common = {
         genderNone: "Keine Angabe",
         industry: "Branche",
         jobRole: "Berufsrolle",
+        other: "Sonstiges",
         submitWithoutData: "Ohne Angaben abschicken",
         saveRating: "Bewertung speichern",
         cancel: "Abbrechen",
@@ -142,6 +144,7 @@ const common = {
 
         optionsTitle: "Evaluation options",
         ideaSelectionTitle: "Idea selection",
+        selectIdeasInfo: "Enable or disable ideas for the calculation.",
         optionConsiderRound1: "Consider round 1",
         optionConsiderRound2: "Consider round 2",
         optionAppTester: "App tester (no logging, no data collection)",
@@ -194,6 +197,7 @@ const common = {
         genderNone: "Prefer not to say",
         industry: "Industry",
         jobRole: "Job role",
+        other: "Other",
         submitWithoutData: "Submit without info",
         saveRating: "Save rating",
         cancel: "Cancel",
@@ -254,6 +258,7 @@ const common = {
 
         optionsTitle: "Options d'évaluation",
         ideaSelectionTitle: "Sélection d'idées",
+        selectIdeasInfo: "Activez ou désactivez des idées pour le calcul.",
         optionConsiderRound1: "Prenez en compte le tour 1",
         optionConsiderRound2: "Prenez en compte le tour 2",
         optionAppTester: "Testeur d'app (pas de journalisation, pas de collecte de données)",
@@ -307,6 +312,7 @@ const common = {
         genderNone: "Aucune indication",
         industry: "Secteur",
         jobRole: "Rôle professionnel",
+        other: "Autre",
 
         submitWithoutData: "Envoyez sans information",
         saveRating: "Enregistrez l'évaluation",

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -46,7 +46,7 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
       </div>
       <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
         <h2 className="text-lg font-semibold text-center">{t('ideaSelectionTitle')}</h2>
-        <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
+        <p className="mt-4 text-center text-sm text-gray-700">{t('selectIdeasInfo')}</p>
       </div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
     </div>


### PR DESCRIPTION
## Summary
- allow choosing industry and job role from dropdowns with "Other" option
- add translations for "Other" and idea selection info text
- update IdeaSelectionPage to show correct info text

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685417d11a0c83209ea5d54c56e52989