### PR TITLE
Allow editing personal data after saving

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,12 +13,11 @@ import { SelectDataPage } from "./pages/SelectDataPage";
 import { IdeaSelectionPage } from "./pages/IdeaSelectionPage";
 import { CombinationSelectionPage } from "./pages/CombinationSelectionPage";
 import { PersonalDataPage } from "./pages/PersonalDataPage";
-import type { SaveRunResponse, UserData } from "./api/saveRun";
+import type { UserData } from "./api/saveRun";
 import { ConfigSummaryPage } from "./pages/ConfigSummaryPage";
 import { CalcResultsPage } from "./pages/CalcResultsPage";
 
 // import { KombiInfoModal } from "./components/KombiInfoModal"; // ← entfernt, da ungenutzt
-import { SaveRunSuccess } from "./components/SaveRunSuccess";
 import { StatusToast } from "./components/StatusToast";
 
 import { getSessionId, setPageStatus } from "./utils/session";
@@ -49,9 +48,6 @@ function App() {
   const [dev2Mode, setDev2Mode] = useState(
     sessionStorage.getItem('dev2mode') === 'true'
   );
-  const [saveRunSuccessOpen, setSaveRunSuccessOpen] = useState(false);
-  const [saveRunMessage, setSaveRunMessage] = useState("");
-  const [saveRunId, setSaveRunId] = useState<string | undefined>(undefined);
   const [statusToastOpen, setStatusToastOpen] = useState(false);
   const [statusToastMessage, setStatusToastMessage] = useState("");
   const [statusToastType, setStatusToastType] = useState<"success" | "error" | "info">("info");
@@ -272,18 +268,6 @@ const handleKombiSammlungChange = useCallback(
     setKombiInfoPayload(null);
   }; */
 
-  const handleCloseSaveRunSuccess = () => {
-    setSaveRunSuccessOpen(false);
-    setSaveRunMessage("");
-    setSaveRunId(undefined);
-  };
-
-
-  const handleSaveSuccess = (result: SaveRunResponse) => {
-    setSaveRunId(result.run_id);
-    setSaveRunMessage(result.message);
-    setSaveRunSuccessOpen(true);
-  };
 
   const handleUserDataSaved = (data: UserData | undefined) => {
     setUserData(data);
@@ -406,7 +390,6 @@ return (
                   gewichtungen: {},
                   ergebnisRanking: [],
                 }}
-                onSaveSuccess={handleSaveSuccess}
                 onUserDataSaved={handleUserDataSaved}
               />
             </div>
@@ -438,15 +421,6 @@ return (
           )}
         />
       </Routes>
-
-
-      <SaveRunSuccess
-        open={saveRunSuccessOpen}
-        message={saveRunMessage}
-        runId={saveRunId}
-        onClose={handleCloseSaveRunSuccess}
-        isTester={appTester}
-      />
 
       {/* <KombiInfoModal
         open={kombiInfoModalOpen}

--- a/frontend/src/components/SaveRunSuccess.tsx
+++ b/frontend/src/components/SaveRunSuccess.tsx
@@ -5,8 +5,10 @@ type Props = {
   open: boolean;
   message: string;
   runId?: string;
-  onClose: () => void;
+  onClose?: () => void;
   isTester?: boolean;
+  inline?: boolean;
+  onEdit?: () => void;
 };
 
 export const SaveRunSuccess: React.FC<Props> = ({
@@ -15,35 +17,51 @@ export const SaveRunSuccess: React.FC<Props> = ({
   runId,
   onClose,
   isTester,
+  inline = false,
+  onEdit,
 }) => {
   const { t } = useTranslation();
 
   if (!open) return null;
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex items-center justify-center text-center">
-      <div className="bg-white p-6 rounded-xl shadow-xl max-w-sm w-full relative">
-        <h2 className="font-bold text-lg mb-2">{t("thankYouForRating")}</h2>
-        <div className="mb-3 text-gray-700">{message}</div>
-        {runId && !isTester && (
-          <div className="text-xs text-gray-500 mb-2">
-            {t("evaluationId")}: <span className="font-mono">{runId}</span>
-          </div>
-        )}
-        {isTester && (
-          <div className="text-sm text-blue-600">
-            {/* Hinweis mit fett formatiertem "keine" im i18n-Text */}
-            <span
-              dangerouslySetInnerHTML={{ __html: t("testerModeNotice") }}
-            />
-          </div>
-        )}
+  const content = (
+    <div className="bg-white p-6 rounded-xl shadow-xl max-w-sm w-full text-center relative">
+      <h2 className="font-bold text-lg mb-2">{t("thankYouForRating")}</h2>
+      <div className="mb-3 text-gray-700">{message}</div>
+      {runId && !isTester && (
+        <div className="text-xs text-gray-500 mb-2">
+          {t("evaluationId")}: <span className="font-mono">{runId}</span>
+        </div>
+      )}
+      {isTester && (
+        <div className="text-sm text-blue-600">
+          <span dangerouslySetInnerHTML={{ __html: t("testerModeNotice") }} />
+        </div>
+      )}
+      {onEdit ? (
+        <button
+          className="mt-4 bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700"
+          onClick={onEdit}
+        >
+          {t("editData")}
+        </button>
+      ) : (
         <button
           className="mt-4 bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700"
           onClick={onClose}
         >
           {t("close")}
         </button>
-      </div>
+      )}
+    </div>
+  );
+
+  if (inline) {
+    return <div className="flex justify-center">{content}</div>;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex items-center justify-center text-center">
+      {content}
     </div>
   );
 };

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -85,6 +85,7 @@ const common = {
         submitWithoutData: "Ohne Angaben abschicken",
         saveRating: "Bewertung speichern",
         cancel: "Abbrechen",
+        editData: "Daten überarbeiten",
         submitError: "Fehler beim Senden der Bewertung. Bitte erneut versuchen.",
 
         disabled: "Deaktiviert",
@@ -197,6 +198,7 @@ const common = {
         submitWithoutData: "Submit without info",
         saveRating: "Save rating",
         cancel: "Cancel",
+        editData: "Edit data",
         submitError: "Error sending rating. Please try again.",
 
         disabled: "Disabled",
@@ -311,6 +313,7 @@ const common = {
         submitWithoutData: "Envoyez sans information",
         saveRating: "Enregistrez l'évaluation",
         cancel: "Annulez",
+        editData: "Modifier les données",
         submitError: "Erreur lors de l'envoi de l'évaluation. Veuillez réessayer.",
 
         disabled: "Désactivé",

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -5,6 +5,7 @@ import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 import { StatistikForm } from '../components/StatistikForm';
+import { SaveRunSuccess } from '../components/SaveRunSuccess';
 
 import type { BewertungsLaufPayload, UserData, SaveRunResponse } from '../api/saveRun';
 
@@ -12,7 +13,7 @@ import type { BewertungsLaufPayload, UserData, SaveRunResponse } from '../api/sa
 interface Props {
   tester: boolean;
   payload: Omit<BewertungsLaufPayload, 'tester' | 'userData'>;
-  onSaveSuccess: (result: SaveRunResponse) => void;
+  onSaveSuccess?: (result: SaveRunResponse) => void;
   onUserDataSaved: (data: UserData | undefined) => void;
 }
 
@@ -26,6 +27,8 @@ export const PersonalDataPage = ({
   const navigate = useNavigate();
   const [formOpen, setFormOpen] = useState(true);
   const [saved, setSaved] = useState(false);
+  const [saveMessage, setSaveMessage] = useState("");
+  const [saveRunId, setSaveRunId] = useState<string | undefined>(undefined);
 
 
   useEffect(() => {
@@ -37,11 +40,13 @@ export const PersonalDataPage = ({
   const handleSaveSuccess = (result: SaveRunResponse) => {
     setSaved(true);
     setFormOpen(false);
+    setSaveMessage(result.message);
+    setSaveRunId(result.run_id);
     logEvent(getSessionId(), 'personal-data', result);
     if (!result.error && result.status === 'ok') {
       setPageStatus('personal', 'ok');
     }
-    onSaveSuccess(result);
+    if (onSaveSuccess) onSaveSuccess(result);
   };
 
   const handleNext = () => {
@@ -70,6 +75,19 @@ export const PersonalDataPage = ({
             onUserDataSaved={onUserDataSaved}
           />
         </div>
+      )}
+      {!formOpen && saved && (
+        <SaveRunSuccess
+          open={true}
+          inline
+          message={saveMessage}
+          runId={saveRunId}
+          isTester={tester}
+          onEdit={() => {
+            setFormOpen(true);
+            setSaved(false);
+          }}
+        />
       )}
       <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />


### PR DESCRIPTION
## Summary
- make SaveRunSuccess usable inline and add edit button
- add `editData` translation in all languages
- show success message inline on personal data page with edit option
- remove unused modal logic from `App.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6854186c184c832095a0336727fb7593