### PR TITLE
Fix success modal visibility

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -294,6 +294,13 @@ const handleKombiSammlungChange = useCallback(
     setStatusToastMessage("");
   };
 
+  // Ensure success modal is only visible on the personal data page
+  useEffect(() => {
+    if (location.pathname !== "/personal") {
+      setSaveRunSuccessOpen(false);
+    }
+  }, [location.pathname]);
+
   useEffect(() => {
     loadIdeen(aktuelleIdeensammlung);
     loadKombis(aktuelleKombiSammlung);


### PR DESCRIPTION
## Summary
- ensure the save success modal is hidden once the user leaves the personal page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685418c501988320be5b58f49fb04beb