### PR TITLE
Make page descriptions configurable and update tester mode

### DIFF
--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { saveRun } from "../api/saveRun";
+import pageDescriptions from "../pageDescriptions";
 import type { SaveRunResponse, BewertungsLaufPayload, UserData } from "../api/saveRun";
 
 
@@ -123,6 +124,22 @@ export const StatistikForm: React.FC<Props> = ({
 
   if (!open) return null;
 
+  if (tester) {
+    const content = (
+      <div className="bg-white rounded-xl p-6 shadow-xl max-w-md w-full text-center">
+        <p>{pageDescriptions.personalData.testerMessage}</p>
+      </div>
+    );
+    if (inline) {
+      return <div className="flex justify-center">{content}</div>;
+    }
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex items-center justify-center">
+        {content}
+      </div>
+    );
+  }
+
   if (inline) {
     return (
       <div className="flex justify-center">
@@ -141,10 +158,10 @@ export const StatistikForm: React.FC<Props> = ({
             </button>
           )}
 
-          <h2 className="font-bold text-lg mb-2">{t("helpImproveStats")}</h2>
+          <h2 className="font-bold text-lg mb-2">{pageDescriptions.personalData.helpTitle}</h2>
           <p
             className="text-gray-700 text-sm mb-4"
-            dangerouslySetInnerHTML={{ __html: t("infoVoluntary") }}
+            dangerouslySetInnerHTML={{ __html: pageDescriptions.personalData.infoText }}
           />
           {!tester && (
             <div className="space-y-2 mb-3">
@@ -280,10 +297,10 @@ export const StatistikForm: React.FC<Props> = ({
             ×
           </button>
         )}
-        <h2 className="font-bold text-lg mb-2">{t("helpImproveStats")}</h2>
+        <h2 className="font-bold text-lg mb-2">{pageDescriptions.personalData.helpTitle}</h2>
         <p
           className="text-gray-700 text-sm mb-4"
-          dangerouslySetInnerHTML={{ __html: t("infoVoluntary") }}
+          dangerouslySetInnerHTML={{ __html: pageDescriptions.personalData.infoText }}
         />
 
         {!tester && (

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -74,8 +74,8 @@ const common = {
         testerModeNotice: "Hinweis: Im App-Tester-Modus wird <b>keine</b> Speicherung vorgenommen.",
 
         helpImproveStats: "Bitte helfen Sie uns, die Statistik zu verbessern",
-        infoVoluntary: "Ihre Angaben sind <b>freiwillig</b>, anonym und werden nur für Auswertungen gespeichert. Sie können auch als App-Tester fortfahren, dann wird <b>gar nichts</b> gespeichert.",
-        appTesterMode: "App-Tester: Keine Daten speichern und keine Angaben machen",
+        infoVoluntary: "Ihre Angaben sind <b>freiwillig</b>, anonym und werden nur für Auswertungen gespeichert.",
+        appTesterMode: "App-Tester Modus, keine Datenabfrage",
         age: "Alter",
         gender: "Geschlecht",
         genderMale: "Männlich",
@@ -209,8 +209,8 @@ const common = {
         testerModeNotice: "Note: In app tester mode, <b>no</b> data is saved.",
 
         helpImproveStats: "Please help us improve the statistics",
-        infoVoluntary: "Your information is <b>voluntary</b>, anonymous, and used only for evaluations. You can also continue as an app tester; then <b>no</b> data is saved.",
-        appTesterMode: "App tester: Do not save data or provide info",
+        infoVoluntary: "Your information is <b>voluntary</b>, anonymous, and used only for evaluations.",
+        appTesterMode: "App tester mode, no data collection",
         age: "Age",
         gender: "Gender",
         genderMale: "Male",
@@ -344,8 +344,8 @@ const common = {
         testerModeNotice: "Remarque : En mode testeur d'application, <b>aucune</b> donnée n'est enregistrée.",
 
         helpImproveStats: "Aidez-nous à améliorer les statistiques",
-        infoVoluntary: "Vos informations sont <b>volontaires</b>, anonymes et utilisées uniquement pour des évaluations. Vous pouvez également continuer en tant que testeur d'application ; alors <b>aucune</b> donnée n'est enregistrée.",
-        appTesterMode: "Testeur d'app : ne pas enregistrer les données ni fournir d'informations",
+        infoVoluntary: "Vos informations sont <b>volontaires</b>, anonymes et utilisées uniquement pour des évaluations.",
+        appTesterMode: "Mode testeur d'app, aucune collecte de données",
 
         age: "Âge",
         gender: "Sexe",

--- a/frontend/src/pageDescriptions.ts
+++ b/frontend/src/pageDescriptions.ts
@@ -1,0 +1,17 @@
+const pageDescriptions = {
+  startIntro: 'Mit diesem Tool können Sie Ideen bewerten und kombinieren.',
+  ideaSelection: {
+    title: 'Ideenauswahl',
+    info: 'Hier können Sie Ideen für die Berechnung aktivieren oder deaktivieren.',
+  },
+  combinationSelection: {
+    info: 'Bitte Gewichtung der Kombinationen auswählen.',
+  },
+  personalData: {
+    helpTitle: 'Bitte helfen Sie uns, die Statistik zu verbessern',
+    infoText:
+      'Ihre Angaben sind <b>freiwillig</b>, anonym und werden nur für Auswertungen gespeichert.',
+    testerMessage: 'App-Tester Modus, keine Datenabfrage',
+  },
+};
+export default pageDescriptions;

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
+import pageDescriptions from '../pageDescriptions';
 import { logEvent } from '../api/logEvent';
 
 interface Props {
@@ -72,7 +73,7 @@ export const CombinationSelectionPage = ({
           showDataRelease={false}
           showRoundOptions={showRoundOptions}
         />
-        <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
+        <p className="mt-4 text-center text-sm text-gray-700">{pageDescriptions.combinationSelection.info}</p>
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -3,6 +3,7 @@ import { IdeenSelector } from '../components/IdeenSelector';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
+import pageDescriptions from '../pageDescriptions';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 
@@ -45,8 +46,8 @@ export const IdeaSelectionPage = ({ ideen, sprache, onIdeenUpdate }: Props) => {
         </div>
       </div>
       <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
-        <h2 className="text-lg font-semibold text-center">{t('ideaSelectionTitle')}</h2>
-        <p className="mt-4 text-center text-sm text-gray-700">{t('selectIdeasInfo')}</p>
+        <h2 className="text-lg font-semibold text-center">{pageDescriptions.ideaSelection.title}</h2>
+        <p className="mt-4 text-center text-sm text-gray-700">{pageDescriptions.ideaSelection.info}</p>
       </div>
       <IdeenSelector ideen={ideen} sprache={sprache} onUpdate={onIdeenUpdate} />
     </div>

--- a/frontend/src/pages/PersonalDataPage.tsx
+++ b/frontend/src/pages/PersonalDataPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
+import pageDescriptions from '../pageDescriptions';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
 import { StatistikForm } from '../components/StatistikForm';
@@ -64,30 +65,36 @@ export const PersonalDataPage = ({
 
   return (
     <div className="text-center">
-      {formOpen && (
-        <div className="mb-6 flex justify-center">
-          <StatistikForm
-            open={true}
-            inline
-            tester={tester}
-            payload={payload}
-            onSaveSuccess={handleSaveSuccess}
-            onUserDataSaved={onUserDataSaved}
-          />
-        </div>
-      )}
-      {!formOpen && saved && (
-        <SaveRunSuccess
-          open={true}
-          inline
-          message={saveMessage}
-          runId={saveRunId}
-          isTester={tester}
-          onEdit={() => {
-            setFormOpen(true);
-            setSaved(false);
-          }}
-        />
+      {tester ? (
+        <p className="mb-6">{pageDescriptions.personalData.testerMessage}</p>
+      ) : (
+        <>
+          {formOpen && (
+            <div className="mb-6 flex justify-center">
+              <StatistikForm
+                open={true}
+                inline
+                tester={tester}
+                payload={payload}
+                onSaveSuccess={handleSaveSuccess}
+                onUserDataSaved={onUserDataSaved}
+              />
+            </div>
+          )}
+          {!formOpen && saved && (
+            <SaveRunSuccess
+              open={true}
+              inline
+              message={saveMessage}
+              runId={saveRunId}
+              isTester={tester}
+              onEdit={() => {
+                setFormOpen(true);
+                setSaved(false);
+              }}
+            />
+          )}
+        </>
       )}
       <div className="mt-8 mb-6 flex justify-between">
         <ResetButton />

--- a/frontend/src/pages/StartPage.tsx
+++ b/frontend/src/pages/StartPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { markSessionStarted } from '../utils/session';
+import pageDescriptions from '../pageDescriptions';
 
 interface Props {
   dev2Mode: boolean;
@@ -21,7 +22,7 @@ export const StartPage = ({ dev2Mode, onStart }: Props) => {
       <h1 className="text-4xl font-bold mb-8 text-[#1d2c5b] tracking-tight drop-shadow">
         {t('title')}
       </h1>
-      <p className="mb-6 text-gray-700">{t('introText')}</p>
+      <p className="mb-6 text-gray-700">{pageDescriptions.startIntro}</p>
       <div className="flex items-center justify-center gap-4 mt-4">
         <button
           onClick={handleStart}


### PR DESCRIPTION
## Summary
- centralize page description texts in `pageDescriptions.ts`
- use the new config on start, idea selection and combination pages
- show a simple tester message on personal data page
- hide statistics form when tester mode is enabled
- remove 'Submit without info' logic and update translations

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68542a76f6e48320aef9ede947414129