### PR TITLE
Add config flags for checkboxes

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -117,7 +117,16 @@ class Config:
     @property
     def enable_usage_logging(self): return self._feature("enable_usage_logging")
     @property
-    def show_round_options(self): return self._feature("show_round_options")
+    def show_round_options(self):
+        if "show_round_options" in self.config["Features"]:
+            return self._feature("show_round_options")
+        if "consider1checkbox" in self.config["Features"]:
+            return self._feature("consider1checkbox")
+        return False
+
+    @property
+    def show_tester_checkbox(self):
+        return self.testerbutton_enabled
 
     @property
     def log_level(self):

--- a/backend/main.py
+++ b/backend/main.py
@@ -243,6 +243,7 @@ async def get_features():
     """Liefert Feature-Flags aus der Backend-Konfiguration."""
     return {
         "show_round_options": config.show_round_options,
+        "show_tester_checkbox": config.show_tester_checkbox,
         "loadingscreen_duration": config.duration_loadingscreen,
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
   const [appTester, setAppTester] = useState(false);
   const [datenfreigabe, setDatenfreigabe] = useState<"offen" | "anonym" | "keine">("offen");
   const [showRoundOptions, setShowRoundOptions] = useState(true);
+  const [showTesterOption, setShowTesterOption] = useState(true);
   const [loadingScreenDuration, setLoadingScreenDuration] = useState(0.8);
   const [gewichtungen, setGewichtungen] = useState<any[]>([]);
   const [rankingEintraege, setRankingEintraege] = useState<any[]>([]);
@@ -63,6 +64,9 @@ function App() {
       .then((data) => {
         if (typeof data.show_round_options === "boolean") {
           setShowRoundOptions(data.show_round_options);
+        }
+        if (typeof data.show_tester_checkbox === "boolean") {
+          setShowTesterOption(data.show_tester_checkbox);
         }
         if (typeof data.loadingscreen_duration === "number") {
           setLoadingScreenDuration(data.loadingscreen_duration);
@@ -398,6 +402,7 @@ function App() {
                   appTester={appTester}
                   datenfreigabe={datenfreigabe}
                   showRoundOptions={showRoundOptions}
+                  showTesterOption={showTesterOption}
                   onGewichtungenUpdate={handleGewichtungenUpdate}
                   onOptionsChange={handleBewertungsOptionenChange}
                 />

--- a/frontend/src/components/BewertungsOptionen.tsx
+++ b/frontend/src/components/BewertungsOptionen.tsx
@@ -9,6 +9,7 @@ type BewertungsOptionenProps = {
   onChange: (field: string, value: any) => void;
   showDataRelease?: boolean;
   showRoundOptions?: boolean;
+  showTesterOption?: boolean;
 };
 
 export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
@@ -19,6 +20,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
   onChange,
   showDataRelease = true,
   showRoundOptions = true,
+  showTesterOption = true,
 }) => {
   const { t } = useTranslation();
 
@@ -52,15 +54,17 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
           </>
         )}
 
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={appTester}
-            onChange={(e) => onChange("appTester", e.target.checked)}
-            className="accent-[#1d2c5b]"
-          />
-          {t("optionAppTester")}
-        </label>
+        {showTesterOption && (
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={appTester}
+              onChange={(e) => onChange("appTester", e.target.checked)}
+              className="accent-[#1d2c5b]"
+            />
+            {t("optionAppTester")}
+          </label>
+        )}
       </div>
 
       {showDataRelease && (

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -15,6 +15,7 @@ interface Props {
   appTester: boolean;
   datenfreigabe: 'offen' | 'anonym' | 'keine';
   showRoundOptions?: boolean;
+  showTesterOption?: boolean;
   onGewichtungenUpdate: (g: any[]) => void;
   onOptionsChange: (field: string, value: any) => void;
 }
@@ -26,6 +27,7 @@ export const CombinationSelectionPage = ({
   appTester,
   datenfreigabe,
   showRoundOptions = true,
+  showTesterOption = true,
   onGewichtungenUpdate,
   onOptionsChange,
 }: Props) => {
@@ -72,6 +74,7 @@ export const CombinationSelectionPage = ({
           onChange={onOptionsChange}
           showDataRelease={false}
           showRoundOptions={showRoundOptions}
+          showTesterOption={showTesterOption}
         />
         <p className="mt-4 text-center text-sm text-gray-700">{pageDescriptions.combinationSelection.info}</p>
       </div>

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -17,6 +17,7 @@ interface Props {
   onBewertungsOptionenChange: (field: string, value: any) => void;
   onGewichtungenUpdate: (g: any[]) => void;
   showRoundOptions?: boolean;
+  showTesterOption?: boolean;
   onOpenStatistikForm?: (inline?: boolean) => void;
 }
 
@@ -32,6 +33,7 @@ export const ConfigPage = ({
   onBewertungsOptionenChange,
   onGewichtungenUpdate,
   showRoundOptions = true,
+  showTesterOption = true,
   onOpenStatistikForm = () => {},
 }: Props) => {
   const { t } = useTranslation();
@@ -47,6 +49,7 @@ export const ConfigPage = ({
           datenfreigabe={datenfreigabe}
           onChange={onBewertungsOptionenChange}
           showRoundOptions={showRoundOptions}
+          showTesterOption={showTesterOption}
         />
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />


### PR DESCRIPTION
## Summary
- allow disabling round option and tester checkboxes via backend config
- expose new flags from the backend
- hide checkboxes in frontend based on the flags

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68544a8641dc8320820ca683f023afd3