### PR TITLE
Fix save_run message language support

### DIFF
--- a/backend/i18n_backend.py
+++ b/backend/i18n_backend.py
@@ -45,6 +45,21 @@ MESSAGES = {
         "de": "Lesefehler:",
         "en": "Read error:",
         "fr": "Erreur de lecture :"
+    },
+    "run_saved": {
+        "de": "Bewertungslauf gespeichert",
+        "en": "Evaluation run saved",
+        "fr": "Exécution de l'évaluation enregistrée"
+    },
+    "run_not_saved_tester": {
+        "de": "Tester-Modus: Bewertungslauf NICHT gespeichert.",
+        "en": "Tester mode: evaluation run NOT saved.",
+        "fr": "Mode testeur : l'exécution de l'évaluation n'a PAS été enregistrée."
+    },
+    "invalid_data": {
+        "de": "Ungültige Daten",
+        "en": "Invalid data",
+        "fr": "Données invalides"
     }
 }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -330,11 +330,12 @@ ARCHIVE_FOLDER.mkdir(parents=True, exist_ok=True)
 @app.post("/save_run")
 async def save_run(data: dict):
     """Speichert einen Bewertungslauf als JSON-Datei."""
+    lang = data.get("lang", config.default_language)
     if not data or "tester" not in data:
-        raise HTTPException(status_code=400, detail="Ung\u00fcltige Daten")
+        raise HTTPException(status_code=400, detail=t("invalid_data", lang))
 
     if data.get("tester"):
-        return {"message": "Tester-Modus: Bewertungslauf NICHT gespeichert.", "status": "ok"}
+        return {"message": t("run_not_saved_tester", lang), "status": "ok"}
 
     run_id = str(uuid.uuid4())
     filepath = STORAGE_FOLDER / f"{run_id}.json"
@@ -342,7 +343,7 @@ async def save_run(data: dict):
     with open(filepath, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
-    return {"message": "Bewertungslauf gespeichert", "run_id": run_id, "status": "ok"}
+    return {"message": t("run_saved", lang), "run_id": run_id, "status": "ok"}
 
 
 # ---- Nutzungsdaten speichern ----

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -417,6 +417,7 @@ function App() {
                     deaktivierteIdeen: ideen.filter((i) => !i.aktiv).map((i) => i.id),
                     gewichtungen: {},
                     ergebnisRanking: [],
+                    lang: language,
                   }}
                   onUserDataSaved={handleUserDataSaved}
                 />

--- a/frontend/src/api/saveRun.ts
+++ b/frontend/src/api/saveRun.ts
@@ -11,6 +11,7 @@ export interface UserData {
 export interface BewertungsLaufPayload {
   tester: boolean; // true, wenn Tester-Modus aktiviert
   userData?: UserData;
+  lang?: string;
   ideenSammlung: string; // Dateiname oder ID der verwendeten Ideensammlung
   kombiSammlung: string; // Dateiname oder ID der verwendeten Kombisammlung
   gewaehlteIdeen: string[]; // IDs der aktiven Ideen

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -26,7 +26,7 @@ export const StatistikForm: React.FC<Props> = ({
   onClose,
   inline = false,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   useEffect(() => {
     setSaveRunStatus("idle");
   }, []);
@@ -93,6 +93,7 @@ export const StatistikForm: React.FC<Props> = ({
     const fullPayload: BewertungsLaufPayload = {
       ...payload,
       tester,
+      lang: i18n.language,
       userData: tester
         ? undefined
         : {


### PR DESCRIPTION
## Summary
- add localized messages for save_run results
- send language info when saving runs from the frontend
- handle `lang` parameter in backend `/save_run`

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm run typecheck`
- `python -m py_compile backend/i18n_backend.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68544acf6cf48320aeebf54c929efcee