### PR TITLE
Fix combination weighting i18n

### DIFF
--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
-import pageDescriptions from '../pageDescriptions';
 import { logEvent } from '../api/logEvent';
 
 interface Props {
@@ -73,7 +72,7 @@ export const CombinationSelectionPage = ({
           showDataRelease={false}
           showRoundOptions={showRoundOptions}
         />
-        <p className="mt-4 text-center text-sm text-gray-700">{pageDescriptions.combinationSelection.info}</p>
+        <p className="mt-4 text-center text-sm text-gray-700">{t('selectWeightsInfo')}</p>
       </div>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
       


### PR DESCRIPTION
## Summary
- remove pageDescriptions usage from combination page
- use i18n key `selectWeightsInfo` on the CombinationSelection page

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68544c3be5888320b310a6fffbdca943