### PR TITLE
Fix numeric parsing in Excel loader

### DIFF
--- a/backend/loader/excel_loader.py
+++ b/backend/loader/excel_loader.py
@@ -38,6 +38,10 @@ class ExcelLoader:
         # IDs als Spaltennamen verwenden
         daten.columns = [self.spalten_ids.get(i, f"Unbekannt_{i}") for i in range(len(spalten_namen))]
 
+        # Versuche numerische Daten in echte Zahlen zu konvertieren
+        # Dadurch können Berechnungen im Backend korrekt ausgeführt werden
+        daten = daten.apply(pd.to_numeric, errors="ignore")
+
         if "#ID#" in daten.columns:
             daten.rename(columns={"#ID#": "ID"}, inplace=True)
 


### PR DESCRIPTION
## Summary
- ensure numeric columns from Excel are parsed as numbers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile backend/loader/excel_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_685452381c208320bf129c2d9f981504