### PR TITLE
Ensure save status resets on session start

### DIFF
--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -20,6 +20,7 @@ export function resetSessionId(): string {
 export function markSessionStarted() {
   sessionStorage.setItem("sessionStarted", "true");
   resetPageStatus();
+  setSaveRunStatus('idle');
 }
 
 export function hasSessionStarted(): boolean {
@@ -29,6 +30,7 @@ export function hasSessionStarted(): boolean {
 export function clearSession() {
   sessionStorage.removeItem("sessionStarted");
   resetSessionId();
+  setSaveRunStatus('idle');
 }
 
 export function resetPageStatus() {


### PR DESCRIPTION
## Summary
- reset backend save status when a new session starts
- also reset the save status when clearing a session

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685453322ed483208d073056f37beca8