### PR TITLE
Fix API serialization issue

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -405,7 +405,18 @@ async def calculate_ranking(payload: dict):
     results = []
     for idee_id, score in ranking_series.items():
         idee = ideen_df.loc[idee_id]
-        details = {col: kombi_ergebnisse.loc[idee_id, col] for col in kombi_ergebnisse.columns}
+        raw_details = {
+            col: kombi_ergebnisse.loc[idee_id, col]
+            for col in kombi_ergebnisse.columns
+        }
+
+        # FastAPI's jsonable_encoder cannot handle numpy scalar types, therefore
+        # convert them explicitly to Python float values
+        details = {
+            col: (float(val) if val == val else None)
+            for col, val in raw_details.items()
+        }
+
         results.append({
             "id": str(idee_id),
             "name": idee.get("titel", ""),


### PR DESCRIPTION
## Summary
- handle numpy scalar types in the calculate API

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6854577d41548320be8d8514bd6544a9