### PR TITLE
Fix language selection for Kombi config

### DIFF
--- a/backend/frontend_config.py
+++ b/backend/frontend_config.py
@@ -10,9 +10,10 @@ def lade_frontend_konfiguration(kombis_df: pd.DataFrame) -> dict:
     for _, row in kombis_df.iterrows():
         kombi = {
             "id": row.get("Kombi_ID", ""),
-            "name": row["Kombinationsname"],
-            "beschreibung": row.get("Beschreibung", ""),
-            "formel": row.get("Formeltext", ""),
+            # Prefer language-specific columns if available
+            "name": row.get("titel", row.get("Kombinationsname", "")),
+            "beschreibung": row.get("beschreibung", row.get("Beschreibung", "")),
+            "formel": row.get("formeltext", row.get("Formeltext", "")),
             "gewichtung": 3,  # Standardgewichtung "neutral"
             "aktiv": True,
             "einheit": row.get("Einheit", ""),


### PR DESCRIPTION
## Summary
- prefer `titel`, `beschreibung`, and `formeltext` columns when preparing combination config

## Testing
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68545f215d2083208e88d6ce5be3409e