### PR TITLE
Add info block and title to SelectDataPage

### DIFF
--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -41,6 +41,8 @@ const common = {
         introText: "Mit diesem Tool können Sie Ideen bewerten und kombinieren.",
         fieldsRequired: "Bitte alle Felder ausfüllen.",
         invalidAge: "Bitte ein realistisches Alter eingeben (10-120).",
+        masterDataSelectionTitle: "Stammdaten Auswahl",
+        selectDataInfo: "Hier kann eine Beschreibung dieser Seite stehen, wie eigene Dateien hochgeladen werden und worauf zu achten ist.",
 
         resetWarning: "Warnung! Durch Zur\u00fccksetzen werden alle eingegebenen Daten gel\u00f6scht. Zur\u00fccksetzen oder abbrechen?",
 
@@ -177,6 +179,8 @@ const common = {
         introText: "This tool lets you rate and combine ideas.",
         fieldsRequired: "Please fill in all fields.",
         invalidAge: "Please enter a realistic age (10-120).",
+        masterDataSelectionTitle: "Master data selection",
+        selectDataInfo: "Here you can add a description of this page, how to upload your own files and what to pay attention to.",
         resetWarning: "Warning! Resetting will remove all entered data. Reset or cancel?",
 
         currentIdeaCollection: "Current idea collection",
@@ -312,6 +316,8 @@ const common = {
         introText: "Cet outil vous permet d'évaluer et de combiner des idées.",
         fieldsRequired: "Veuillez remplir tous les champs.",
         invalidAge: "Veuillez entrer un âge réaliste (10-120).",
+        masterDataSelectionTitle: "Sélection des données de base",
+        selectDataInfo: "Vous pouvez ajouter ici une description de cette page, comment téléverser vos propres fichiers et ce à quoi il faut faire attention.",
         resetWarning: "Attention! La r\u00e9initialisation supprimera toutes les donn\u00e9es saisies. R\u00e9initialiser ou annuler?",
 
         currentIdeaCollection: "Collection d'idées actuelle",

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -52,6 +52,9 @@ export const SelectDataPage = ({
           </button>
         </div>
       </div>
+      <h2 className="text-lg font-semibold text-center mb-4">
+        {t('masterDataSelectionTitle')}
+      </h2>
       <CollectionSelectorIdeas
         aktuelleSammlungName={aktuelleIdeensammlung}
         onSammlungChange={onIdeenSammlungChange}
@@ -62,6 +65,11 @@ export const SelectDataPage = ({
         onSammlungChange={onKombiSammlungChange}
         onUpload={onKombiUpload}
       />
+      <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8">
+        <p className="text-sm text-gray-700 text-center">
+          {t('selectDataInfo')}
+        </p>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add page heading and info block for master data selection
- provide i18n strings for new content

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68552b3d06b08320a2c112e4983c614c