### PR TITLE
Adjust inactive item styling

### DIFF
--- a/frontend/src/components/IdeenSelector.tsx
+++ b/frontend/src/components/IdeenSelector.tsx
@@ -58,7 +58,10 @@ export const IdeenSelector: React.FC<Props> = ({
             : {};
 
         return (
-          <div key={idee.id} className="border rounded-xl p-4 bg-white shadow-sm">
+          <div
+            key={idee.id}
+            className={`border rounded-xl p-4 shadow-sm ${idee.aktiv ? 'bg-white' : 'bg-gray-100 text-gray-500'}`}
+          >
             <div className="flex justify-between items-center">
               <div>
                 <h2 className="font-semibold text-lg">{name}</h2>
@@ -75,7 +78,7 @@ export const IdeenSelector: React.FC<Props> = ({
                     onChange={() => toggleActive(idee.id)}
                     className="mr-1"
                   />
-                  {t("active")}
+                  {idee.aktiv ? t("active") : t("disabled")}
                 </label>
                 <button
                   onClick={() => toggleExpand(idee.id)}

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -50,7 +50,10 @@ export const WeightingSelector: React.FC<Props> = ({
   return (
     <div className="space-y-6">
       {(kombinationen || []).map((kombi) => (
-        <div key={kombi.id} className="border rounded-xl p-4 shadow-sm bg-white">
+        <div
+          key={kombi.id}
+          className={`border rounded-xl p-4 shadow-sm ${kombi.gewichtung === 0 ? 'bg-gray-100 text-gray-500' : 'bg-white'}`}
+        >
           <div className="flex justify-between items-center">
             <div>
               <h2 className="text-lg font-semibold">{kombi.name}</h2>


### PR DESCRIPTION
## Summary
- show grey background for deactivated ideas and combinations
- display `disabled` label when an idea is not active

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68552c0934a483208b6b6d87b65012b3