### PR TITLE
Fix type mismatch for MUI Select

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import {
   Select,
   Toolbar,
   Typography,
+  SelectChangeEvent,
 } from "@mui/material";
 
 import { getSessionId, setPageStatus } from "./utils/session";
@@ -151,8 +152,8 @@ function App() {
   );
 
 
-  const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const lang = e.target.value;
+  const handleLanguageChange = (event: SelectChangeEvent) => {
+    const lang = event.target.value;
     setLanguage(lang);
     i18n.changeLanguage(lang);
   };


### PR DESCRIPTION
## Summary
- use `SelectChangeEvent` from MUI for language dropdown

## Testing
- `npm run lint` *(fails: Invalid package.json)*
- `npm run typecheck` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685531af52248320ab57c29fef4789e1