### PR TITLE
Add divider to SelectDataPage

### DIFF
--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -6,7 +6,7 @@ import { ResetButton } from '../components/ResetButton';
 import { useTranslation } from 'react-i18next';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
-import { Box, Button } from '@mui/material';
+import { Box, Button, Divider } from '@mui/material';
 
 interface Props {
   aktuelleIdeensammlung: string;
@@ -66,6 +66,8 @@ export const SelectDataPage = ({
         onSammlungChange={onKombiSammlungChange}
         onUpload={onKombiUpload}
       />
+
+      <Divider sx={{ my: 4 }} />
 
       <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8 mt-8">
         <p className="text-sm text-gray-700 text-center">


### PR DESCRIPTION
## Summary
- insert Divider after `CollectionSelectorKombis`
- position info block below divider

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553fb15d108320b6c69215822e623a