### PR TITLE
Add footer component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import type { SelectChangeEvent } from "@mui/material/Select";
 import { getSessionId, setPageStatus } from "./utils/session";
 import { devConfig } from "./devConfig";
 import { DevStatusBar } from "./components/DevStatusBar";
+import { Footer } from "./components/Footer";
 import { calculateRanking } from "./api/calculateRanking";
 
 function App() {
@@ -487,6 +488,7 @@ function App() {
           type={statusToastType}
         />
       </Container>
+      <Footer />
     </div>
   );
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export const Footer: React.FC = () => (
+  <footer className="text-center text-sm py-4">
+    <p className="mb-2">
+      Team Sustainabuild (Gruppe4 Projektentwicklung) – alle Rechte vorbehalten ©
+    </p>
+    <Link to="/impressum" className="text-blue-600 underline">
+      Impressum/Kontakt
+    </Link>
+  </footer>
+);
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add `Footer` component with organization credit and Impressum link
- show footer below page content in `App`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553fb3c78c8320861e7b514f0aaa54