### PR TITLE
Adjust colors to match website style

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
 
   
   </head>
-  <body class="bg-[#f5f7fa] font-inter">
+  <body class="bg-[#F0F5FA] font-inter">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/components/BewertungsOptionen.tsx
+++ b/frontend/src/components/BewertungsOptionen.tsx
@@ -37,7 +37,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
                 type="checkbox"
                 checked={runde1}
                 onChange={(e) => onChange("runde1", e.target.checked)}
-                className="accent-[#1d2c5b]"
+                className="accent-[#4ab866]"
               />
               {t("optionConsiderRound1")}
             </label>
@@ -47,7 +47,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
                 type="checkbox"
                 checked={runde2}
                 onChange={(e) => onChange("runde2", e.target.checked)}
-                className="accent-[#1d2c5b]"
+                className="accent-[#4ab866]"
               />
               {t("optionConsiderRound2")}
             </label>
@@ -60,7 +60,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
               type="checkbox"
               checked={appTester}
               onChange={(e) => onChange("appTester", e.target.checked)}
-              className="accent-[#1d2c5b]"
+              className="accent-[#4ab866]"
             />
             {t("optionAppTester")}
           </label>

--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -143,7 +143,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         <button
           type="button"
           onClick={handleUploadButtonClick}
-          className="px-4 py-2 bg-blue-600 text-white rounded"
+          className="px-4 py-2 bg-green-600 text-white rounded"
         >
           {t("uploadFile")}
         </button>

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -143,7 +143,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         <button
           type="button"
           onClick={handleUploadButtonClick}
-          className="px-4 py-2 bg-blue-600 text-white rounded"
+          className="px-4 py-2 bg-green-600 text-white rounded"
         >
           {t("uploadFile")}
         </button>

--- a/frontend/src/components/IdeenSelector.tsx
+++ b/frontend/src/components/IdeenSelector.tsx
@@ -82,7 +82,7 @@ export const IdeenSelector: React.FC<Props> = ({
                 </label>
                 <button
                   onClick={() => toggleExpand(idee.id)}
-                  className="text-blue-600 text-sm underline"
+                  className="text-green-600 text-sm underline"
                   type="button"
                 >
                   {expandedId === idee.id ? t("hideAttributes") : t("showAttributes")}

--- a/frontend/src/components/KombiInfoModal.tsx
+++ b/frontend/src/components/KombiInfoModal.tsx
@@ -80,7 +80,7 @@ export const KombiInfoModal: React.FC<Props> = ({ open, kombi, sprache, onClose 
           </div>
         )}
         <button
-          className="mt-4 bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700"
+          className="mt-4 bg-green-600 text-white rounded px-4 py-2 font-semibold hover:bg-green-700"
           onClick={onClose}
         >
           {t("close")}

--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -54,7 +54,7 @@ type Props = {
             </div>
             <div className="col-span-2 text-center">
               <button
-                className="text-blue-600 hover:underline"
+                className="text-green-600 hover:underline"
                 title={t("showDescription")}
                 onClick={() => setOpenId(openId === eintrag.id ? null : eintrag.id)}
                 type="button"
@@ -65,7 +65,7 @@ type Props = {
             <div className="col-span-3 text-right">
               {eintrag.details && (
                 <button
-                  className="text-blue-600 hover:underline"
+                  className="text-green-600 hover:underline"
                   onClick={() => setOpenId(openId === eintrag.id ? null : eintrag.id)}
                   type="button"
                 >
@@ -77,7 +77,7 @@ type Props = {
           {/* Beschreibung und Details ausklappbar */}
           {openId === eintrag.id && (
             <div
-              className="col-span-12 bg-blue-50 rounded-b p-3 mt-2"
+              className="col-span-12 bg-green-50 rounded-b p-3 mt-2"
               style={{ gridColumn: "1 / -1" }}
             >
               {eintrag.beschreibung && (

--- a/frontend/src/components/SaveRunSuccess.tsx
+++ b/frontend/src/components/SaveRunSuccess.tsx
@@ -33,20 +33,20 @@ export const SaveRunSuccess: React.FC<Props> = ({
         </div>
       )}
       {isTester && (
-        <div className="text-sm text-blue-600">
+        <div className="text-sm text-green-600">
           <span dangerouslySetInnerHTML={{ __html: t("testerModeNotice") }} />
         </div>
       )}
       {onEdit ? (
         <button
-          className="mt-4 bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700"
+          className="mt-4 bg-green-600 text-white rounded px-4 py-2 font-semibold hover:bg-green-700"
           onClick={onEdit}
         >
           {t("editData")}
         </button>
       ) : (
         <button
-          className="mt-4 bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700"
+          className="mt-4 bg-green-600 text-white rounded px-4 py-2 font-semibold hover:bg-green-700"
           onClick={onClose}
         >
           {t("close")}

--- a/frontend/src/components/StatistikForm.tsx
+++ b/frontend/src/components/StatistikForm.tsx
@@ -261,7 +261,7 @@ export const StatistikForm: React.FC<Props> = ({
                     !berufsrolle ||
                     !isValidAge(alter)))
               }
-              className="bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700 disabled:opacity-50"
+              className="bg-green-600 text-white rounded px-4 py-2 font-semibold hover:bg-green-700 disabled:opacity-50"
             >
               {tester ? t("submitWithoutData") : t("saveRating")}
             </button>
@@ -401,7 +401,7 @@ export const StatistikForm: React.FC<Props> = ({
                   !berufsrolle ||
                   !isValidAge(alter)))
             }
-            className="bg-blue-600 text-white rounded px-4 py-2 font-semibold hover:bg-blue-700 disabled:opacity-50"
+            className="bg-green-600 text-white rounded px-4 py-2 font-semibold hover:bg-green-700 disabled:opacity-50"
           >
             {tester ? t("submitWithoutData") : t("saveRating")}
           </button>

--- a/frontend/src/components/StatusToast.tsx
+++ b/frontend/src/components/StatusToast.tsx
@@ -29,7 +29,7 @@ export const StatusToast: React.FC<Props> = ({
   const colors: Record<string, string> = {
     success: "bg-green-600",
     error: "bg-red-600",
-    info: "bg-blue-600",
+    info: "bg-green-600",
   };
 
   // Optional: Könnte hier noch übersetzte Icons verwenden, falls gewünscht.

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -63,7 +63,7 @@ export const WeightingSelector: React.FC<Props> = ({
             </div>
             <button
               onClick={() => toggleInfo(kombi.id)}
-              className="text-blue-600 text-sm underline"
+              className="text-green-600 text-sm underline"
               type="button"
             >
               {expandedId === kombi.id

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,13 +8,13 @@ import App from './App.tsx'
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#1d2c5b',
+      main: '#4ab866',
     },
     secondary: {
-      main: '#00a99d',
+      main: '#e8ffe8',
     },
     background: {
-      default: '#f5f7fa',
+      default: '#F0F5FA',
     },
   },
 })

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -59,7 +59,7 @@ export const ConfigPage = ({
             onOpenStatistikForm && onOpenStatistikForm(false);
             navigate('/results');
           }}
-          className="px-4 py-2 bg-blue-600 text-white rounded"
+          className="px-4 py-2 bg-green-600 text-white rounded"
         >
           {t('next')}
         </button>

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -38,7 +38,7 @@ export const UploadPage = ({
       <div className="mt-6 text-center">
         <button
           onClick={() => navigate('/config')}
-          className="px-4 py-2 bg-blue-600 text-white rounded"
+          className="px-4 py-2 bg-green-600 text-white rounded"
         >
           {t('next')}
         </button>


### PR DESCRIPTION
## Summary
- switch theme palette to green
- update body background
- replace blue button and text classes with green
- tweak accent colors in options

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855415b53908320acd6a5d44b678b80