### PR TITLE
Center and uppercase header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -332,9 +332,6 @@ function App() {
       <AppBar position="sticky" color="primary" sx={{ mb: 2 }}>
         <Toolbar sx={{ justifyContent: 'space-between' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <Typography variant="h6" color="inherit" sx={{ mr: 2 }}>
-              Bewertungsmatrix
-            </Typography>
             <Typography
               variant="caption"
               sx={{ bgcolor: 'primary.light', px: 1, py: 0.5, borderRadius: 1 }}
@@ -354,6 +351,14 @@ function App() {
                 label={<Typography variant="caption">Dev2 mode</Typography>}
               />
             )}
+          </Box>
+          <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'center' }}>
+            <Typography
+              variant="h6"
+              sx={{ color: '#fff', textTransform: 'uppercase' }}
+            >
+              Bewertungsmatrix
+            </Typography>
           </Box>
           <Select
             id="lang-select"


### PR DESCRIPTION
## Summary
- move header title into its own flex box
- center title and display it in uppercase white text

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68554338ec8c83208cd0ffee2e569e76