### PR TITLE
Add Impressum page and centered header with logo

### DIFF
--- a/frontend/logo.svg
+++ b/frontend/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#1a237e" />
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="white" font-family="Arial, sans-serif">S</text>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { PersonalDataPage } from "./pages/PersonalDataPage";
 import type { UserData } from "./api/saveRun";
 import { ConfigSummaryPage } from "./pages/ConfigSummaryPage";
 import { CalcResultsPage } from "./pages/CalcResultsPage";
+import { ImpressumPage } from "./pages/ImpressumPage";
 
 // import { KombiInfoModal } from "./components/KombiInfoModal"; // ← entfernt, da ungenutzt
 import { StatusToast } from "./components/StatusToast";
@@ -329,8 +330,16 @@ function App() {
   return (
     <div className="min-h-screen w-full bg-gray-200 text-gray-900 font-inter flex flex-col items-center pb-10">
       <AppBar position="sticky" color="primary" sx={{ mb: 2 }}>
-        <Toolbar sx={{ justifyContent: 'space-between' }}>
+        <Toolbar
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr auto 1fr',
+            alignItems: 'center',
+            gap: 2,
+          }}
+        >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Box component="img" src="/logo.svg" alt="Logo" sx={{ height: 32 }} />
             <Typography
               variant="caption"
               sx={{ bgcolor: 'primary.light', px: 1, py: 0.5, borderRadius: 1 }}
@@ -351,25 +360,25 @@ function App() {
               />
             )}
           </Box>
-          <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'center' }}>
-            <Typography
-              variant="h6"
-              sx={{ color: '#fff', textTransform: 'uppercase' }}
-            >
-              Bewertungsmatrix
-            </Typography>
-          </Box>
-          <Select
-            id="lang-select"
-            size="small"
-            value={language}
-            onChange={handleLanguageChange}
-            sx={{ bgcolor: 'background.paper', minWidth: 80 }}
+          <Typography
+            variant="h6"
+            sx={{ color: '#fff', textTransform: 'uppercase', textAlign: 'center' }}
           >
-            <MenuItem value="de">Deutsch</MenuItem>
-            <MenuItem value="en">English</MenuItem>
-            <MenuItem value="fr">Français</MenuItem>
-          </Select>
+            Bewertungsmatrix
+          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Select
+              id="lang-select"
+              size="small"
+              value={language}
+              onChange={handleLanguageChange}
+              sx={{ bgcolor: 'background.paper', minWidth: 80 }}
+            >
+              <MenuItem value="de">Deutsch</MenuItem>
+              <MenuItem value="en">English</MenuItem>
+              <MenuItem value="fr">Français</MenuItem>
+            </Select>
+          </Box>
         </Toolbar>
       </AppBar>
 
@@ -468,6 +477,7 @@ function App() {
               <CalcResultsPage rankingEintraege={rankingEintraege} />
             )}
           />
+          <Route path="/impressum" element={<ImpressumPage />} />
         </Routes>
 
         {/* <KombiInfoModal

--- a/frontend/src/pages/ImpressumPage.tsx
+++ b/frontend/src/pages/ImpressumPage.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { PageContainer } from '../components/PageContainer';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+export const ImpressumPage: React.FC = () => (
+  <PageContainer>
+    <Typography variant="h5" component="h1" mb={4} textAlign="center">
+      Impressum
+    </Typography>
+    <Box className="space-y-4">
+      <Typography>
+        <strong>Angaben gemäß § 5 TMG:</strong>
+      </Typography>
+      <Typography>
+        Verantwortlich für den Inhalt dieser Webseite und der Ideen-Bewertungs-Matrix:<br/>
+        Gregor Kordowich<br/>
+        c/o Technische Hochschule Würzburg-Schweinfurt (THWS)<br/>
+        Röntgenring 8<br/>
+        97070 Würzburg
+      </Typography>
+      <Typography>
+        E-Mail: <a href="mailto:gregor.kordowich@study.thws.de" className="text-blue-600 underline">gregor.kordowich@study.thws.de</a>
+      </Typography>
+      <Typography>
+        <strong>Gruppenzugehörigkeit:</strong><br/>
+        Team Sustainabuild (ehemals Gruppe4-Projektentwicklung)<br/>
+        Gruppe 4 der Projektarbeit im B6-B7 zur Entwicklung eines Produktes der Nachhaltigkeit<br/>
+        Sommersemester 2025 und Wintersemester 2026<br/>
+        Studiengang Bauingenieurwesen
+      </Typography>
+      <Typography>
+        <strong>Verantwortlich gemäß § 55 Abs. 2 RStV:</strong><br/>
+        Gregor Kordowich, c/o THWS, Röntgenring 8, 97070 Würzburg
+      </Typography>
+      <Typography>
+        <strong>Hinweis:</strong><br/>
+        Dies ist eine studentische Projektwebsite im Rahmen einer Pflichtarbeit an der THWS. Für den Inhalt der „Ideen-Bewertungs-Matrix“ ist der oben genannte Verantwortliche zuständig.
+      </Typography>
+      <Typography>
+        Alle Angaben und Ergebnisse, die durch die Nutzung der Ideen-Bewertungs-Matrix erzeugt werden, dienen ausschließlich zu Studien- und Demonstrationszwecken. Es wird keine Gewähr für die Aktualität, Korrektheit, Vollständigkeit oder Qualität der bereitgestellten Informationen und Berechnungsergebnisse übernommen.
+      </Typography>
+      <Typography>
+        Für Schäden materieller oder ideeller Art, die durch die Nutzung oder Nichtnutzung der angebotenen Informationen bzw. durch die Nutzung fehlerhafter und unvollständiger Informationen oder durch die Eingabe eigener Daten verursacht werden, wird keine Haftung übernommen.
+      </Typography>
+      <Typography>
+        Bitte beachten Sie, dass die eingegebenen Daten und die daraus resultierenden Ergebnisse ausschließlich im Rahmen des Projekts verwendet werden und keine rechtlich verbindlichen Empfehlungen oder Bewertungen darstellen.
+      </Typography>
+    </Box>
+  </PageContainer>
+);
+
+export default ImpressumPage;


### PR DESCRIPTION
## Summary
- center the header using a grid layout and add the project logo
- create a new Impressum page with full legal information
- register the Impressum page in the router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685549b9e9d48320af0f09e2ca80720a