### PR TITLE
Add clickable header logo with translations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ import Select from "@mui/material/Select";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import type { SelectChangeEvent } from "@mui/material/Select";
-import { getSessionId, setPageStatus } from "./utils/session";
+import { getSessionId, setPageStatus, clearSession, resetSessionId } from "./utils/session";
 import { devConfig } from "./devConfig";
 import { DevStatusBar } from "./components/DevStatusBar";
 import { Footer } from "./components/Footer";
@@ -155,6 +155,13 @@ function App() {
     const lang = event.target.value;
     setLanguage(lang);
     i18n.changeLanguage(lang);
+  };
+
+  const handleHeaderReset = () => {
+    if (!window.confirm(t('resetWarning'))) return;
+    clearSession();
+    resetSessionId();
+    window.location.href = '/';
   };
 
   const handleIdeenSammlungChange = useCallback(
@@ -351,12 +358,27 @@ function App() {
               />
             )}
           </Box>
-          <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'center' }}>
+          <Box
+            sx={{
+              flexGrow: 1,
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              gap: 1,
+            }}
+          >
+            <img
+              src="/vite.svg"
+              alt={t('appName')}
+              style={{ height: 32, cursor: 'pointer' }}
+              onClick={handleHeaderReset}
+            />
             <Typography
               variant="h6"
-              sx={{ color: '#fff', textTransform: 'uppercase' }}
+              sx={{ color: '#fff', textTransform: 'uppercase', cursor: 'pointer' }}
+              onClick={handleHeaderReset}
             >
-              Bewertungsmatrix
+              {t('appName')}
             </Typography>
           </Box>
           <Select

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -2,6 +2,7 @@ const common = {
     de: {
       translation: {
         title: "Matrix Bewertungstool",
+        appName: "Bewertungsmatrix",
         selectCollection: "Ideensammlung auswählen",
         selectCombination: "Kombinationssammlung auswählen",
         uploadFile: "Datei hochladen",
@@ -140,6 +141,7 @@ const common = {
     en: {
       translation: {
         title: "Matrix Evaluation Tool",
+        appName: "Evaluation Matrix",
         selectCollection: "Select idea collection",
         selectCombination: "Select combination collection",
         uploadFile: "Upload file",
@@ -277,6 +279,7 @@ const common = {
     fr: {
       translation: {
         title: "Outil d'évaluation de la matrice",
+        appName: "Matrice d'évaluation",
         selectCollection: "Sélectionnez une collection d'idées",
         selectCombination: "Sélectionnez une collection de combinaisons",
         uploadFile: "Téléversez un fichier",


### PR DESCRIPTION
## Summary
- add `appName` label to i18n translations
- display logo and header text with `appName`
- make header logo and text reset session like reset button

## Testing
- `npm run lint` *(fails: cannot find package)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68554a7394648320875c056e542f7737