### PR TITLE
Adjust container width for desktop

### DIFF
--- a/frontend/src/components/PageContainer.tsx
+++ b/frontend/src/components/PageContainer.tsx
@@ -7,7 +7,9 @@ interface Props {
 
 export const PageContainer: React.FC<Props> = ({ children, className = '' }) => {
   return (
-    <div className={`w-[40%] max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 ${className}`.trim()}>
+    <div
+      className={`w-full md:w-3/5 max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl p-10 my-10 ${className}`.trim()}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- expand desktop container width to 3/5 of the screen

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68554b046e3083209712d1e53f65f46e