### PR TITLE
Fix duplicate header logo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -362,7 +362,6 @@ function App() {
   >
     {/* Linke Seite */}
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-      <Box component="img" src="/Logo.png" alt="Logo" sx={{ height: 32 }} />
       <Typography
         variant="caption"
         sx={{ bgcolor: 'primary.light', px: 1, py: 0.5, borderRadius: 1 }}


### PR DESCRIPTION
## Summary
- remove logo from left side of header

## Testing
- `bash ./codex-setup.sh` *(fails: registry access blocked)*
- `pytest -q`
- `npm run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68555ce9942c8320b1392aae0264e07f