### PR TITLE
Load attribute names from description file

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -79,6 +79,13 @@ class Config:
         return self.config["Dateien"]["upload_dir"]
 
     @property
+    def attribute_description_file(self):
+        return self.config["Dateien"].get(
+            "attribute_description_file",
+            "uploads/attributdescription/CW25_AttributDescrition.xlsx",
+        )
+
+    @property
     def template_dir(self):
         # Pfad relativ zur Projektstruktur (z. B. "templates" → ../templates)
         raw_path = self.config["Dateien"]["templatedir"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -254,6 +254,39 @@ async def get_features():
         "loadingscreen_duration": config.duration_loadingscreen,
     }
 
+# ---- Attributbeschreibungen laden ----
+@app.get("/api/attribute_descriptions")
+async def get_attribute_descriptions(lang: str = Query(default=config.default_language)):
+    """Liefert Namen und Beschreibungen der Attribute in der gewählten Sprache."""
+    desc_path = Path(config.attribute_description_file)
+    if not desc_path.exists():
+        return JSONResponse(status_code=404, content={"error": t("file_not_found", lang)})
+
+    try:
+        df = pd.read_excel(desc_path, header=None, dtype=str, keep_default_na=False)
+        if df.shape[0] < 7:
+            return JSONResponse(status_code=400, content={"error": t("not_enough_rows", lang)})
+
+        attr_ids = [str(val).strip() for val in df.iloc[0, 1:]]
+
+        if lang.startswith("en"):
+            desc_row, name_row = 2, 5
+        elif lang.startswith("fr"):
+            desc_row, name_row = 3, 6
+        else:
+            desc_row, name_row = 1, 4
+
+        descriptions = [str(val).strip() for val in df.iloc[desc_row, 1:1+len(attr_ids)]]
+        names = [str(val).strip() for val in df.iloc[name_row, 1:1+len(attr_ids)]]
+
+        result = {
+            attr_id: {"name": name, "description": desc}
+            for attr_id, name, desc in zip(attr_ids, names, descriptions)
+        }
+        return {"attributes": result}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
 
 
 

--- a/backend/matrixconfig.ini
+++ b/backend/matrixconfig.ini
@@ -16,6 +16,7 @@ templatedir = templates
 logfile = logs/backend.log
 autosave_dir = saves/
 upload_dir = uploads/
+attribute_description_file = uploads/attributdescription/CW25_AttributDescrition.xlsx
 
 #Referenzdatei für Validator beim Upload eigener Dateien festlegen
 valid_ideen_template = uploads/selectionideas/standard_ideen.xlsx

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,7 @@ function App() {
   );
 
   const [ideen, setIdeen] = useState<any[]>([]);
-  const [attributeMeta, setAttributeMeta] = useState<Record<string, {name: string; unit: string}>>({});
+  const [attributeMeta, setAttributeMeta] = useState<Record<string, {name: string; unit: string; description?: string}>>({});
   const [runde1, setRunde1] = useState(true);
   const [runde2, setRunde2] = useState(true);
   const [appTester, setAppTester] = useState(false);
@@ -114,6 +114,22 @@ function App() {
     [sessionId, t],
   );
 
+  const fetchAttributeDescriptions = useCallback(
+    async (lang: string) => {
+      try {
+        const url = `${import.meta.env.VITE_API_URL}/api/attribute_descriptions?lang=${lang}`;
+        const response = await fetch(url);
+        if (!response.ok) return {};
+        const data = await response.json();
+        return (data.attributes as Record<string, { name: string; description: string }>) || {};
+      } catch (err) {
+        console.error('Failed to load attribute descriptions', err);
+        return {};
+      }
+    },
+    []
+  );
+
   const loadIdeen = useCallback(
     async (filename: string) => {
       // Clear previous ideas to avoid flicker while loading new data
@@ -124,13 +140,22 @@ function App() {
       const columns: string[] = Array.isArray(data.columns) ? data.columns : [];
       const columnNames: string[] = Array.isArray(data.column_names) ? data.column_names : [];
 
-      const meta: Record<string, { name: string; unit: string }> = {};
+      const meta: Record<string, { name: string; unit: string; description?: string }> = {};
       columns.forEach((id, idx) => {
         if (id.startsWith("#-#")) {
           const num = id.slice(3);
           const unitId = `#+#${num}`;
           const unit = columnNames[columns.indexOf(unitId)] || "";
           meta[id] = { name: columnNames[idx] || id, unit };
+        }
+      });
+      const descData = await fetchAttributeDescriptions(language);
+      Object.entries(descData).forEach(([id, d]) => {
+        if (meta[id]) {
+          meta[id].name = d.name || meta[id].name;
+          meta[id].description = d.description;
+        } else {
+          meta[id] = { name: d.name, unit: '', description: d.description };
         }
       });
       setAttributeMeta(meta);
@@ -145,7 +170,7 @@ function App() {
       });
       setIdeen(parsed);
     },
-    [fetchCollectionContent],
+    [fetchCollectionContent, fetchAttributeDescriptions, language],
   );
 
   const loadKombis = useCallback(

--- a/frontend/src/components/IdeenSelector.tsx
+++ b/frontend/src/components/IdeenSelector.tsx
@@ -26,7 +26,7 @@ type Idee = {
   [key: string]: any; // für dynamische Sprachspalten wie '#t_de#1', '#t_en#1', etc.
 };
 
-type AttributeMeta = Record<string, { name: string; unit: string }>;
+type AttributeMeta = Record<string, { name: string; unit: string; description?: string }>;
 
 type Props = {
   ideen?: Idee[]; // optional für Robustheit
@@ -136,7 +136,7 @@ export const IdeenSelector: React.FC<Props> = ({
                           <Table size="small">
                             <TableBody>
                               {Object.entries(attribute).map(([key, value]) => {
-                                const meta = attributeMeta[key] || { name: key, unit: '' };
+                                const meta = attributeMeta[key] || { name: key, unit: '', description: '' };
                                 return (
                                   <TableRow key={key}>
                                     <TableCell>{meta.name}</TableCell>
@@ -169,7 +169,7 @@ export const IdeenSelector: React.FC<Props> = ({
         <DialogTitle>{attributeMeta[infoAttr || ""]?.name || ""}</DialogTitle>
         <DialogContent>
           <Typography>
-            {t('attributeDescriptionPlaceholder')}
+            {attributeMeta[infoAttr || ""]?.description || t('attributeDescriptionPlaceholder')}
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -9,7 +9,7 @@ import { PageContainer } from '../components/PageContainer';
 interface Props {
   ideen: any[];
   sprache: 'de' | 'en' | 'fr';
-  attributeMeta: Record<string, { name: string; unit: string }>;
+  attributeMeta: Record<string, { name: string; unit: string; description?: string }>;
   runde1: boolean;
   runde2: boolean;
   appTester: boolean;

--- a/frontend/src/pages/IdeaSelectionPage.tsx
+++ b/frontend/src/pages/IdeaSelectionPage.tsx
@@ -11,7 +11,7 @@ import { PageContainer } from '../components/PageContainer';
 interface Props {
   ideen: any[];
   sprache: 'de' | 'en' | 'fr';
-  attributeMeta: Record<string, { name: string; unit: string }>;
+  attributeMeta: Record<string, { name: string; unit: string; description?: string }>;
   onIdeenUpdate: (ideen: any[]) => void;
 }
 


### PR DESCRIPTION
## Summary
- add config option for attribute description file
- expose `/api/attribute_descriptions` endpoint in the backend
- use descriptions to set attribute names in frontend
- display attribute descriptions in the ideas table dialog

## Testing
- `./codex-setup.sh` *(fails: network access blocked)*
- `pytest -q`
- `npm run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68555d27de308320b103232b239ab2cf