### PR TITLE
Align upload buttons to right side

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@mui/material";
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material/Select";
 import { getSessionId } from "@/utils/session";
 
 type Props = {
@@ -124,21 +131,32 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
 
   return (
     <div className="mb-4">
-      <label className="block font-semibold mb-1">{t("selectCollection")}</label>
-      <select
-        className="border border-gray-300 p-2 rounded-md w-full max-w-xs bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
-        value={auswahl}
-        onChange={(e) => setAuswahl(e.target.value)}
-        disabled={sammlungListe.length === 0}
-      >
-        {sammlungListe.map((datei) => (
-          <option key={datei} value={datei}>
-            {datei}
-          </option>
-        ))}
-      </select>
-      <div className="mt-2 flex items-center space-x-4">
-        <Button variant="contained" component="label" size="small">
+      <div className="flex items-end justify-between gap-4">
+        <FormControl size="small" sx={{ flexGrow: 1, maxWidth: 320 }}>
+          <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
+          <Select
+            labelId="ideas-select-label"
+            value={auswahl}
+            label={t("selectCollection")}
+            onChange={(e: SelectChangeEvent<string>) =>
+              setAuswahl(e.target.value as string)
+            }
+            disabled={sammlungListe.length === 0}
+          >
+            {sammlungListe.map((datei) => (
+              <MenuItem key={datei} value={datei}>
+                {datei}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <div className="flex items-center space-x-4">
+          <Button
+            variant="contained"
+            component="label"
+            size="small"
+            sx={{ px: 1.5, py: 0.5 }}
+        >
           {t("uploadFile")}
           <input
             ref={fileInputRef}
@@ -151,13 +169,15 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
         </Button>
         <Button
           variant="outlined"
+          sx={{ px: 1.5, py: 0.5 }}
           onClick={() =>
             window.open(`${backendUrl}/download_template?type=ideen`, '_blank')
           }
-          size="small"
-        >
-          {t("downloadIdeaTemplate")}
-        </Button>
+            size="small"
+          >
+            {t("downloadIdeaTemplate")}
+          </Button>
+        </div>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@mui/material";
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material/Select";
 import { getSessionId } from "@/utils/session";
 
 type Props = {
@@ -124,21 +131,34 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
 
   return (
     <div className="mb-4">
-      <label className="block font-semibold mb-1">{t("selectCombinationCollection")}</label>
-      <select
-        className="border border-gray-300 p-2 rounded-md w-full max-w-xs bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
-        value={auswahl}
-        onChange={(e) => setAuswahl(e.target.value)}
-        disabled={sammlungListe.length === 0}
-      >
-        {sammlungListe.map((datei) => (
-          <option key={datei} value={datei}>
-            {datei}
-          </option>
-        ))}
-      </select>
-      <div className="mt-2 flex items-center space-x-4">
-        <Button variant="contained" component="label" size="small">
+      <div className="flex items-end justify-between gap-4">
+        <FormControl size="small" sx={{ flexGrow: 1, maxWidth: 320 }}>
+          <InputLabel id="kombis-select-label">
+            {t("selectCombinationCollection")}
+          </InputLabel>
+          <Select
+            labelId="kombis-select-label"
+            value={auswahl}
+            label={t("selectCombinationCollection")}
+            onChange={(e: SelectChangeEvent<string>) =>
+              setAuswahl(e.target.value as string)
+            }
+            disabled={sammlungListe.length === 0}
+          >
+            {sammlungListe.map((datei) => (
+              <MenuItem key={datei} value={datei}>
+                {datei}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <div className="flex items-center space-x-4">
+          <Button
+            variant="contained"
+            component="label"
+            size="small"
+            sx={{ px: 1.5, py: 0.5 }}
+        >
           {t("uploadFile")}
           <input
             ref={fileInputRef}
@@ -151,13 +171,15 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
         </Button>
         <Button
           variant="outlined"
+          sx={{ px: 1.5, py: 0.5 }}
           onClick={() =>
             window.open(`${backendUrl}/download_template?type=kombi`, '_blank')
           }
-          size="small"
-        >
-          {t("downloadCombinationTemplate")}
-        </Button>
+            size="small"
+          >
+            {t("downloadCombinationTemplate")}
+          </Button>
+        </div>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>


### PR DESCRIPTION
## Summary
- fix layout of the ideas and combinations collection selectors so the Upload and Download buttons appear to the right of the dropdown

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68555edcbd688320a10a788b4ccf0310