### PR TITLE
Increase spacing between idea selector and combination list

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -128,7 +128,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   };
 
   return (
-    <div className="mb-4 max-w-xs">
+    <div className="mb-6 max-w-xs">
       <FormControl fullWidth size="small">
         <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
         <Select


### PR DESCRIPTION
## Summary
- add extra bottom margin for idea selector buttons to keep space from following dropdown

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6855673334dc8320809590e53d64cfd5