### PR TITLE
Refine footer layout

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,15 +1,31 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { getRunCount } from "../api/getRunCount";
 
 export const Footer: React.FC = () => {
   const { t } = useTranslation();
+  const [runCount, setRunCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    getRunCount()
+      .then((count) => setRunCount(count))
+      .catch(() => setRunCount(null));
+  }, []);
+
   return (
-    <footer className="text-center text-sm py-4">
-      <p className="mb-2">{t('footerText')}</p>
-      <Link to="/impressum" className="text-blue-600 underline">
-        {t('footerImpressum')}
-      </Link>
+    <footer className="text-sm py-4 flex items-center justify-between flex-wrap">
+      <div className="flex items-center flex-wrap gap-2">
+        <p>{t('footerText')}</p>
+        <Link to="/impressum" className="text-blue-600 underline">
+          {t('footerImpressum')}
+        </Link>
+      </div>
+      {runCount !== null && (
+        <div className="text-xs text-gray-600 ml-4">
+          {t('calculationCounter', { count: runCount })}
+        </div>
+      )}
     </footer>
   );
 };

--- a/frontend/src/pages/StartPage.tsx
+++ b/frontend/src/pages/StartPage.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Box, Button, Typography } from '@mui/material';
 import { PageContainer } from '../components/PageContainer';
 import { markSessionStarted } from '../utils/session';
-import { getRunCount } from '../api/getRunCount';
 
 interface Props {
   dev2Mode: boolean;
@@ -13,13 +12,6 @@ interface Props {
 export const StartPage = ({ dev2Mode, onStart }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [runCount, setRunCount] = useState<number | null>(null);
-
-  useEffect(() => {
-    getRunCount()
-      .then((count) => setRunCount(count))
-      .catch(() => setRunCount(null));
-  }, []);
 
   const handleStart = () => {
     markSessionStarted();
@@ -27,7 +19,7 @@ export const StartPage = ({ dev2Mode, onStart }: Props) => {
     navigate('/select-data');
   };
   return (
-    <PageContainer className="min-h-[80vh] text-center">
+    <PageContainer className="my-auto text-center">
       <Typography variant="h4" component="h1" mb={4} color="primary">
         {t('title')}
       </Typography>
@@ -39,11 +31,6 @@ export const StartPage = ({ dev2Mode, onStart }: Props) => {
           {t('start')}
         </Button>
       </Box>
-      {runCount !== null && (
-        <div className="fixed bottom-2 right-2 text-xs text-gray-600">
-          {t('calculationCounter', { count: runCount })}
-        </div>
-      )}
     </PageContainer>
   );
 };


### PR DESCRIPTION
## Summary
- keep footer on one line on all screen sizes
- place the counter on the far right
- center Start page content so no scrolling is needed

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685566e088c88320b02414e92f4036c0