### PR TITLE
Increase spacing between selector components

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -128,7 +128,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   };
 
   return (
-    <div className="mb-4 max-w-xs">
+    <div className="mb-6 max-w-xs">
       <FormControl fullWidth size="small">
         <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
         <Select

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -127,7 +127,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
   };
 
   return (
-    <div className="mb-4 max-w-xs">
+    <div className="mt-8 mb-4 max-w-xs">
       <FormControl fullWidth size="small">
         <InputLabel id="kombis-select-label">
           {t("selectCombinationCollection")}


### PR DESCRIPTION
## Summary
- add top margin to the combination list selector for better spacing

## Testing
- `./codex-setup.sh` *(fails: network access blocked)*
- `pytest -q`
- `npm run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6855673334dc8320809590e53d64cfd5