### PR TITLE
Improve info display and layout

### DIFF
--- a/frontend/src/components/BewertungsOptionen.tsx
+++ b/frontend/src/components/BewertungsOptionen.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Checkbox, FormControlLabel } from "@mui/material";
 
 type BewertungsOptionenProps = {
   runde1: boolean;
@@ -55,15 +56,15 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
         )}
 
         {showTesterOption && (
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={appTester}
-              onChange={(e) => onChange("appTester", e.target.checked)}
-              className="accent-[#1d2c5b]"
-            />
-            {t("optionAppTester")}
-          </label>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={appTester}
+                onChange={(e) => onChange("appTester", e.target.checked)}
+              />
+            }
+            label={t("optionAppTester") as string}
+          />
         )}
       </div>
 

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -156,7 +156,9 @@ export const WeightingSelector: React.FC<Props> = ({
                     <Box sx={{ p: 2 }}>
                       {kombi.formel && (
                         <Typography>
-                          <b>{t('formula')}:</b> <span style={{ fontFamily: 'monospace' }}>{kombi.formel}</span>
+                          <b>{t('formula')}:</b>{' '}
+                          <span style={{ fontFamily: 'monospace' }}>{kombi.formel}</span>
+                          {kombi.einheit ? ` ${kombi.einheit}` : ''}
                         </Typography>
                       )}
                       {kombi.richtung && (

--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { ResetButton } from '../components/ResetButton';
 import { hasSessionStarted, getSessionId, setPageStatus } from '../utils/session';
 import { logEvent } from '../api/logEvent';
-import { Box, Button, Paper, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { PageContainer } from '../components/PageContainer';
 
 interface Props {
@@ -65,7 +65,7 @@ export const CombinationSelectionPage = ({
           {t('next')}
         </Button>
       </Box>
-      <Paper sx={{ p: 3, mb: 4 }}>
+      <Box sx={{ mb: 4 }}>
         <BewertungsOptionen
           runde1={runde1}
           runde2={runde2}
@@ -79,7 +79,7 @@ export const CombinationSelectionPage = ({
         <Typography mt={2} textAlign="center" color="text.secondary">
           {t('selectWeightsInfo')}
         </Typography>
-      </Paper>
+      </Box>
       <WeightingSelector kombinationen={gewichtungen} onUpdate={onGewichtungenUpdate} />
 
       </Box>


### PR DESCRIPTION
## Summary
- show formula text with unit and evaluation direction in `WeightingSelector`
- remove paper box around evaluation options
- make `appTester` checkbox a MUI component

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68556e3eac8c8320bf13371b9a6794d9