### PR TITLE
Adjust spacing on SelectData dropdowns

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -128,7 +128,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   };
 
   return (
-    <div className="mb-6 max-w-xs">
+    <div className="mb-12 max-w-xs">
       <FormControl fullWidth size="small">
         <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
         <Select
@@ -147,7 +147,7 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
           ))}
         </Select>
       </FormControl>
-      <div className="mt-4 flex items-center space-x-4 justify-end">
+      <div className="mt-6 flex items-center space-x-4 justify-end">
         <Button
           variant="contained"
           component="label"

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -127,7 +127,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
   };
 
   return (
-    <div className="mt-8 mb-4 max-w-xs">
+    <div className="mt-12 mb-4 max-w-xs">
       <FormControl fullWidth size="small">
         <InputLabel id="kombis-select-label">
           {t("selectCombinationCollection")}
@@ -148,7 +148,7 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
           ))}
         </Select>
       </FormControl>
-      <div className="mt-4 flex items-center space-x-4 justify-end">
+      <div className="mt-6 flex items-center space-x-4 justify-end">
         <Button
           variant="contained"
           component="label"


### PR DESCRIPTION
## Summary
- increase bottom margin for ideas selector
- increase top margin for kombi selector
- bump space above button groups

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68556eceeaa883208e360e818ce0ca9e