### PR TITLE
Improve results layout

### DIFF
--- a/frontend/src/components/ExportRankingButton.tsx
+++ b/frontend/src/components/ExportRankingButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Button } from "@mui/material";
 
 type RankingEintrag = {
   id: string;
@@ -50,12 +51,14 @@ export const ExportRankingButton: React.FC<Props> = ({ eintraege, fileName }) =>
   };
 
   return (
-    <button
+    <Button
+      variant="contained"
+      color="primary"
       onClick={handleExport}
-      className="bg-green-600 text-white rounded px-4 py-2 font-semibold hover:bg-green-700 mt-3"
+      size="small"
     >
       {t("exportRankingCSV")}
-    </button>
+    </Button>
   );
 };
 

--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -1,5 +1,16 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  Box,
+  Button,
+  Collapse,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
 
 type RankingEintrag = {
   id: string;
@@ -14,11 +25,10 @@ type Props = {
  // sprache: "de" | "en" | "fr";
 };
 
-//export const Ranking: React.FC<Props> = ({ eintraege = [], sprache }) 
-  export const Ranking = ({ eintraege }: Props) => {
-    // void sprache; //
-  const [openId, setOpenId] = useState<string | null>(null);
+export const Ranking = ({ eintraege }: Props) => {
   const { t } = useTranslation();
+  const [infoId, setInfoId] = useState<string | null>(null);
+  const [detailIds, setDetailIds] = useState<string[]>([]);
 
   // Robust: Fallback auf leeres Array, sortiere nur wenn Array vorhanden
   const sorted = Array.isArray(eintraege)
@@ -26,99 +36,117 @@ type Props = {
     : [];
 
   return (
-    <div className="w-full max-w-2xl mx-auto mt-6 space-y-3">
-      <h2 className="text-xl font-bold mb-2">{t("rankingTitle")}</h2>
-      <div className="bg-gray-100 rounded-t-lg grid grid-cols-12 px-4 py-2 font-semibold">
-        <div className="col-span-1">{t("rank")}</div>
-        <div className="col-span-4">{t("name")}</div>
-        <div className="col-span-2 text-right">{t("score")}</div>
-        <div className="col-span-2 text-center">{t("info")}</div>
-        <div className="col-span-3"></div>
-      </div>
-      {sorted.length === 0 && (
-        <div className="text-gray-500 px-4 py-2 bg-white border-b rounded-b-lg">
-          {t("noEntries")}
-        </div>
-      )}
-      {sorted.map((eintrag, idx) => (
-        <React.Fragment key={eintrag.id}>
-          <div
-            className={`grid grid-cols-12 px-4 py-2 items-center bg-white border-b ${
-              idx === 0 ? "rounded-t-lg" : ""
-            }`}
-          >
-            <div className="col-span-1 font-bold">{idx + 1}.</div>
-            <div className="col-span-4 font-semibold">{eintrag.name || t("noName")}</div>
-            <div className="col-span-2 text-right">
-              {typeof eintrag.score === "number" ? eintrag.score.toFixed(2) : "–"}
-            </div>
-            <div className="col-span-2 text-center">
-              <button
-                className="text-blue-600 hover:underline"
-                title={t("showDescription")}
-                onClick={() => setOpenId(openId === eintrag.id ? null : eintrag.id)}
-                type="button"
-              >
-                {t("info")}
-              </button>
-            </div>
-            <div className="col-span-3 text-right">
-              {eintrag.details && (
-                <button
-                  className="text-blue-600 hover:underline"
-                  onClick={() => setOpenId(openId === eintrag.id ? null : eintrag.id)}
-                  type="button"
-                >
-                  {t("details")}
-                </button>
-              )}
-            </div>
-          </div>
-          {/* Beschreibung und Details ausklappbar */}
-          {openId === eintrag.id && (
-            <div
-              className="col-span-12 bg-blue-50 rounded-b p-3 mt-2"
-              style={{ gridColumn: "1 / -1" }}
-            >
-              {eintrag.beschreibung && (
-                <div className="mb-2">
-                  <b>{t("description")}:</b> {eintrag.beschreibung}
-                </div>
-              )}
-              {eintrag.details && typeof eintrag.details === "object" && (
-                <div>
-                  <b>{t("combiValues")}:</b>
-                  <table className="mt-2 w-full text-sm">
-                    <thead>
-                      <tr>
-                        <th className="text-left pr-3">{t("combination")}</th>
-                        <th className="text-left">{t("value")}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {Object.entries(eintrag.details).length > 0 ? (
-                        Object.entries(eintrag.details).map(([kombi, wert]) => (
-                          <tr key={kombi}>
-                            <td className="pr-3">{kombi}</td>
-                            <td>{wert}</td>
-                          </tr>
-                        ))
-                      ) : (
-                        <tr>
-                          <td colSpan={2} className="text-gray-400">
-                            {t("noDetails")}
-                          </td>
-                        </tr>
-                      )}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </div>
+    <Box mt={4}>
+      <Typography variant="h6" fontWeight="bold" mb={2}>
+        {t("rankingTitle")}
+      </Typography>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>{t("rank")}</TableCell>
+            <TableCell>{t("name")}</TableCell>
+            <TableCell align="right">{t("score")}</TableCell>
+            <TableCell align="center">{t("info")}</TableCell>
+            <TableCell align="center">{t("details")}</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5}>
+                <Typography color="text.secondary">{t("noEntries")}</Typography>
+              </TableCell>
+            </TableRow>
           )}
-        </React.Fragment>
-      ))}
-    </div>
+          {sorted.map((eintrag, idx) => {
+            const showInfo = infoId === eintrag.id;
+            const showDetails = detailIds.includes(eintrag.id);
+            return (
+              <React.Fragment key={eintrag.id}>
+                <TableRow>
+                  <TableCell>{idx + 1}.</TableCell>
+                  <TableCell>{eintrag.name || t("noName")}</TableCell>
+                  <TableCell align="right">
+                    {typeof eintrag.score === "number" ? eintrag.score.toFixed(2) : "–"}
+                  </TableCell>
+                  <TableCell align="center">
+                    {eintrag.beschreibung && (
+                      <Button size="small" onClick={() => setInfoId(showInfo ? null : eintrag.id)}>
+                        {t("info")}
+                      </Button>
+                    )}
+                  </TableCell>
+                  <TableCell align="center">
+                    {eintrag.details && (
+                      <Button
+                        size="small"
+                        onClick={() =>
+                          setDetailIds((prev) =>
+                            prev.includes(eintrag.id)
+                              ? prev.filter((id) => id !== eintrag.id)
+                              : [...prev, eintrag.id]
+                          )
+                        }
+                      >
+                        {t("details")}
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+                {eintrag.beschreibung && (
+                  <TableRow>
+                    <TableCell colSpan={5} sx={{ p: 0 }}>
+                      <Collapse in={showInfo} timeout="auto" unmountOnExit>
+                        <Box sx={{ p: 2 }}>
+                          <Typography variant="body2">{eintrag.beschreibung}</Typography>
+                        </Box>
+                      </Collapse>
+                    </TableCell>
+                  </TableRow>
+                )}
+                {eintrag.details && (
+                  <TableRow>
+                    <TableCell colSpan={5} sx={{ p: 0 }}>
+                      <Collapse in={showDetails} timeout="auto" unmountOnExit>
+                        <Box sx={{ p: 2 }}>
+                          <Typography variant="subtitle2" fontWeight="bold" mb={1}>
+                            {t("combiValues")}
+                          </Typography>
+                          <Table size="small">
+                            <TableHead>
+                              <TableRow>
+                                <TableCell>{t("combination")}</TableCell>
+                                <TableCell>{t("value")}</TableCell>
+                              </TableRow>
+                            </TableHead>
+                            <TableBody>
+                              {Object.entries(eintrag.details).length > 0 ? (
+                                Object.entries(eintrag.details).map(([kombi, wert]) => (
+                                  <TableRow key={kombi}>
+                                    <TableCell>{kombi}</TableCell>
+                                    <TableCell>{wert}</TableCell>
+                                  </TableRow>
+                                ))
+                              ) : (
+                                <TableRow>
+                                  <TableCell colSpan={2}>
+                                    <Typography color="text.secondary">{t("noDetails")}</Typography>
+                                  </TableCell>
+                                </TableRow>
+                              )}
+                            </TableBody>
+                          </Table>
+                        </Box>
+                      </Collapse>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/CalcResultsPage.tsx
+++ b/frontend/src/pages/CalcResultsPage.tsx
@@ -22,11 +22,11 @@ export const CalcResultsPage = ({ rankingEintraege }: Props) => {
   return (
     <PageContainer>
       <Box>
-        <Ranking eintraege={rankingEintraege} />
-        <Box sx={{ mt: 4, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2 }}>
+        <Box sx={{ mt: 4, mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2 }}>
           <ResetButton />
           <ExportRankingButton eintraege={rankingEintraege} />
         </Box>
+        <Ranking eintraege={rankingEintraege} />
       </Box>
     </PageContainer>
   );


### PR DESCRIPTION
## Summary
- use MUI button for exporting ranking
- redesign ranking table with MUI components
- move Reset/Export buttons above ranking table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685570151480832099bb27018a6e7287