### PR TITLE
Fix options box and add info details

### DIFF
--- a/frontend/src/components/BewertungsOptionen.tsx
+++ b/frontend/src/components/BewertungsOptionen.tsx
@@ -26,7 +26,7 @@ export const BewertungsOptionen: React.FC<BewertungsOptionenProps> = ({
   const { t } = useTranslation();
 
   return (
-    <div className="border rounded-xl p-4 space-y-6 bg-white shadow-sm">
+    <div className="space-y-6">
       <h2 className="text-lg font-semibold text-center">{t("optionsTitle")}</h2>
 
       {/* Checkboxen nebeneinander und zentriert */}

--- a/frontend/src/components/KombiInfoModal.tsx
+++ b/frontend/src/components/KombiInfoModal.tsx
@@ -13,6 +13,7 @@ type KombiInfo = {
   formeltext_de?: string;
   formeltext_en?: string;
   formeltext_fr?: string;
+  einheit?: string;
 };
 
 type Props = {
@@ -48,12 +49,13 @@ export const KombiInfoModal: React.FC<Props> = ({ open, kombi, sprache, onClose 
       : kombi.formeltext_de;
 
   // Bewertungsrichtung übersetzen
-  const bewertungsrichtung =
-    kombi.richtung === "high"
-      ? t("higherIsBetter")
-      : kombi.richtung === "low"
-      ? t("lowerIsBetter")
-      : "";
+  const bewertungsrichtung = (() => {
+    if (!kombi.richtung) return "";
+    const dir = kombi.richtung.toLowerCase();
+    if (["high", "hoch"].includes(dir)) return t("higherIsBetter");
+    if (["low", "niedrig"].includes(dir)) return t("lowerIsBetter");
+    return dir;
+  })();
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 z-50 flex items-center justify-center">
@@ -69,14 +71,12 @@ export const KombiInfoModal: React.FC<Props> = ({ open, kombi, sprache, onClose 
         <div className="mb-2">
           <b>{t("explanation")}:</b> {erklaerung}
         </div>
-        {formeltext && (
+        {(formeltext || kombi.einheit || kombi.richtung) && (
           <div className="mb-2">
-            <b>{t("formula")}:</b> <span className="font-mono">{formeltext}</span>
-          </div>
-        )}
-        {kombi.richtung && (
-          <div className="mb-2">
-            <b>{t("evaluationDirection")}:</b> <span>{bewertungsrichtung}</span>
+            <b>{t("formula")}:</b>{" "}
+            {formeltext && <span className="font-mono">{formeltext}</span>}
+            {kombi.einheit ? ` ${kombi.einheit}` : ""}
+            {kombi.richtung && <> – {bewertungsrichtung}</>}
           </div>
         )}
         <button

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -154,17 +154,26 @@ export const WeightingSelector: React.FC<Props> = ({
                 <TableCell colSpan={hasCategory ? 4 : 3} sx={{ p: 0 }}>
                   <Collapse in={expandedId === kombi.id} timeout="auto" unmountOnExit>
                     <Box sx={{ p: 2 }}>
-                      {kombi.formel && (
+                      {(kombi.formel || kombi.einheit || kombi.richtung) && (
                         <Typography>
-                          <b>{t('formula')}:</b>{' '}
-                          <span style={{ fontFamily: 'monospace' }}>{kombi.formel}</span>
-                          {kombi.einheit ? ` ${kombi.einheit}` : ''}
-                        </Typography>
-                      )}
-                      {kombi.richtung && (
-                        <Typography>
-                          <b>{t('evaluationDirection')}:</b>{' '}
-                          {kombi.richtung.toLowerCase() === 'high' ? t('higherIsBetter') : t('lowerIsBetter')}
+                          {kombi.formel && (
+                            <>
+                              <b>{t('formula')}:</b>{' '}
+                              <span style={{ fontFamily: 'monospace' }}>{kombi.formel}</span>
+                              {kombi.einheit ? ` ${kombi.einheit}` : ''}
+                            </>
+                          )}
+                          {kombi.richtung && (
+                            <>
+                              {' – '}
+                              {(() => {
+                                const dir = kombi.richtung.toLowerCase();
+                                if (['high', 'hoch'].includes(dir)) return t('higherIsBetter');
+                                if (['low', 'niedrig'].includes(dir)) return t('lowerIsBetter');
+                                return dir;
+                              })()}
+                            </>
+                          )}
                         </Typography>
                       )}
                     </Box>


### PR DESCRIPTION
## Summary
- remove border around evaluation options
- show formula text, unit and evaluation direction
- support German direction words

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685573b7c9c083209cef133fc91e84d3