### PR TITLE
Improve result details

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -543,7 +543,10 @@ function App() {
           <Route
             path="/results"
             element={(
-              <CalcResultsPage rankingEintraege={rankingEintraege} />
+              <CalcResultsPage
+                rankingEintraege={rankingEintraege}
+                kombinationen={gewichtungen}
+              />
             )}
           />
           <Route path="/impressum" element={<ImpressumPage />} />

--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -20,12 +20,21 @@ type RankingEintrag = {
   details?: Record<string, any>; // z.B. Attribut-Kombiwertungen
 };
 
-type Props = {
-  eintraege?: RankingEintrag[];
- // sprache: "de" | "en" | "fr";
+type Combination = {
+  id: string;
+  name?: string;
+  formel?: string;
+  einheit?: string;
+  richtung?: string;
+  [key: string]: any;
 };
 
-export const Ranking = ({ eintraege }: Props) => {
+type Props = {
+  eintraege?: RankingEintrag[];
+  kombinationen?: Combination[];
+};
+
+export const Ranking = ({ eintraege, kombinationen }: Props) => {
   const { t } = useTranslation();
   const [infoId, setInfoId] = useState<string | null>(null);
   const [detailIds, setDetailIds] = useState<string[]>([]);
@@ -121,12 +130,30 @@ export const Ranking = ({ eintraege }: Props) => {
                             </TableHead>
                             <TableBody>
                               {Object.entries(eintrag.details).length > 0 ? (
-                                Object.entries(eintrag.details).map(([kombi, wert]) => (
-                                  <TableRow key={kombi}>
-                                    <TableCell>{kombi}</TableCell>
-                                    <TableCell>{wert}</TableCell>
-                                  </TableRow>
-                                ))
+                                Object.entries(eintrag.details).map(([kombi, wert]) => {
+                                  const id = kombi.replace(/^Kombi_/, "");
+                                  const info = kombinationen?.find(k => String(k.id) === id);
+                                  const richtung = info?.richtung?.toLowerCase() || "";
+                                  const dirText =
+                                    richtung === "low"
+                                      ? t("lowerIsBetter")
+                                      : t("higherIsBetter");
+                                  const val =
+                                    typeof wert === "number"
+                                      ? wert.toFixed(3)
+                                      : wert;
+                                  return (
+                                    <TableRow key={kombi}>
+                                      <TableCell>{info?.name || kombi}</TableCell>
+                                      <TableCell>
+                                        {info?.formel ? `${info.formel}: ` : ""}
+                                        {val}
+                                        {info?.einheit ? ` ${info.einheit}` : ""}
+                                        {info?.richtung && ` ${dirText}`}
+                                      </TableCell>
+                                    </TableRow>
+                                  );
+                                })
                               ) : (
                                 <TableRow>
                                   <TableCell colSpan={2}>

--- a/frontend/src/pages/CalcResultsPage.tsx
+++ b/frontend/src/pages/CalcResultsPage.tsx
@@ -9,9 +9,10 @@ import { PageContainer } from '../components/PageContainer';
 
 interface Props {
   rankingEintraege: any[];
+  kombinationen: any[];
 }
 
-export const CalcResultsPage = ({ rankingEintraege }: Props) => {
+export const CalcResultsPage = ({ rankingEintraege, kombinationen }: Props) => {
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -26,7 +27,7 @@ export const CalcResultsPage = ({ rankingEintraege }: Props) => {
           <ResetButton />
           <ExportRankingButton eintraege={rankingEintraege} />
         </Box>
-        <Ranking eintraege={rankingEintraege} />
+        <Ranking eintraege={rankingEintraege} kombinationen={kombinationen} />
       </Box>
     </PageContainer>
   );


### PR DESCRIPTION
## Summary
- expand Ranking details with information about each combination
- pass combination data through CalcResultsPage
- wire App results page to include combination info

## Testing
- `npm run lint` *(fails: Cannot find package index.js)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68557452250c8320a7464863714677e6