### PR TITLE
Improve layout on SelectData page

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -128,52 +128,54 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   };
 
   return (
-    <div className="mb-12 max-w-xs">
-      <FormControl fullWidth size="small">
-        <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
-        <Select
-          labelId="ideas-select-label"
-          value={auswahl}
-          label={t("selectCollection")}
-          onChange={(e: SelectChangeEvent<string>) =>
-            setAuswahl(e.target.value as string)
-          }
-          disabled={sammlungListe.length === 0}
-        >
-          {sammlungListe.map((datei) => (
-            <MenuItem key={datei} value={datei}>
-              {datei}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-      <div className="mt-6 flex items-center space-x-4 justify-end">
-        <Button
-          variant="contained"
-          component="label"
-          size="small"
-          sx={{ px: 1.5, py: 0.5 }}
-        >
-          {t("uploadFile")}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".xlsx"
-            onChange={handleUpload}
-            hidden
-            key={fileKey}
-          />
-        </Button>
-        <Button
-          variant="outlined"
-          sx={{ px: 1.5, py: 0.5 }}
-          onClick={() =>
-            window.open(`${backendUrl}/download_template?type=ideen`, '_blank')
-          }
-          size="small"
-        >
-          {t("downloadIdeaTemplate")}
-        </Button>
+    <div className="max-w-xs">
+      <div className="flex items-start space-x-4">
+        <FormControl fullWidth size="small" sx={{ flexGrow: 1 }}>
+          <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
+          <Select
+            labelId="ideas-select-label"
+            value={auswahl}
+            label={t("selectCollection")}
+            onChange={(e: SelectChangeEvent<string>) =>
+              setAuswahl(e.target.value as string)
+            }
+            disabled={sammlungListe.length === 0}
+          >
+            {sammlungListe.map((datei) => (
+              <MenuItem key={datei} value={datei}>
+                {datei}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <div className="flex flex-col space-y-2">
+          <Button
+            variant="contained"
+            component="label"
+            size="small"
+            sx={{ px: 1.5, py: 0.5 }}
+          >
+            {t("uploadFile")}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".xlsx"
+              onChange={handleUpload}
+              hidden
+              key={fileKey}
+            />
+          </Button>
+          <Button
+            variant="outlined"
+            sx={{ px: 1.5, py: 0.5 }}
+            onClick={() =>
+              window.open(`${backendUrl}/download_template?type=ideen`, '_blank')
+            }
+            size="small"
+          >
+            {t("downloadIdeaTemplate")}
+          </Button>
+        </div>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -127,54 +127,56 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
   };
 
   return (
-    <div className="mt-12 mb-4 max-w-xs">
-      <FormControl fullWidth size="small">
-        <InputLabel id="kombis-select-label">
-          {t("selectCombinationCollection")}
-        </InputLabel>
-        <Select
-          labelId="kombis-select-label"
-          value={auswahl}
-          label={t("selectCombinationCollection")}
-          onChange={(e: SelectChangeEvent<string>) =>
-            setAuswahl(e.target.value as string)
-          }
-          disabled={sammlungListe.length === 0}
-        >
-          {sammlungListe.map((datei) => (
-            <MenuItem key={datei} value={datei}>
-              {datei}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-      <div className="mt-6 flex items-center space-x-4 justify-end">
-        <Button
-          variant="contained"
-          component="label"
-          size="small"
-          sx={{ px: 1.5, py: 0.5 }}
-        >
-          {t("uploadFile")}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".xlsx"
-            onChange={handleUpload}
-            hidden
-            key={fileKey}
-          />
-        </Button>
-        <Button
-          variant="outlined"
-          sx={{ px: 1.5, py: 0.5 }}
-          onClick={() =>
-            window.open(`${backendUrl}/download_template?type=kombi`, '_blank')
-          }
-          size="small"
-        >
-          {t("downloadCombinationTemplate")}
-        </Button>
+    <div className="max-w-xs">
+      <div className="flex items-start space-x-4">
+        <FormControl fullWidth size="small" sx={{ flexGrow: 1 }}>
+          <InputLabel id="kombis-select-label">
+            {t("selectCombinationCollection")}
+          </InputLabel>
+          <Select
+            labelId="kombis-select-label"
+            value={auswahl}
+            label={t("selectCombinationCollection")}
+            onChange={(e: SelectChangeEvent<string>) =>
+              setAuswahl(e.target.value as string)
+            }
+            disabled={sammlungListe.length === 0}
+          >
+            {sammlungListe.map((datei) => (
+              <MenuItem key={datei} value={datei}>
+                {datei}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <div className="flex flex-col space-y-2">
+          <Button
+            variant="contained"
+            component="label"
+            size="small"
+            sx={{ px: 1.5, py: 0.5 }}
+          >
+            {t("uploadFile")}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".xlsx"
+              onChange={handleUpload}
+              hidden
+              key={fileKey}
+            />
+          </Button>
+          <Button
+            variant="outlined"
+            sx={{ px: 1.5, py: 0.5 }}
+            onClick={() =>
+              window.open(`${backendUrl}/download_template?type=kombi`, '_blank')
+            }
+            size="small"
+          >
+            {t("downloadCombinationTemplate")}
+          </Button>
+        </div>
       </div>
       {uploadError && (
         <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -58,24 +58,27 @@ export const SelectDataPage = ({
         {t('masterDataSelectionTitle')}
       </h2>
 
-      <CollectionSelectorIdeas
-        aktuelleSammlungName={aktuelleIdeensammlung}
-        onSammlungChange={onIdeenSammlungChange}
-        onUpload={onIdeenUpload}
-      />
-      <CollectionSelectorKombis
-        aktuelleSammlungName={aktuelleKombiSammlung}
-        onSammlungChange={onKombiSammlungChange}
-        onUpload={onKombiUpload}
-      />
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <CollectionSelectorIdeas
+          aktuelleSammlungName={aktuelleIdeensammlung}
+          onSammlungChange={onIdeenSammlungChange}
+          onUpload={onIdeenUpload}
+        />
 
-      <Divider sx={{ my: 4 }} />
+        <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8 mt-8">
+          <p className="text-sm text-gray-700 text-center">
+            {t('selectDataInfo')}
+          </p>
+        </div>
 
-      <div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8 mt-8">
-        <p className="text-sm text-gray-700 text-center">
-          {t('selectDataInfo')}
-        </p>
-      </div>
+        <Divider sx={{ my: 4, width: '100%' }} />
+
+        <CollectionSelectorKombis
+          aktuelleSammlungName={aktuelleKombiSammlung}
+          onSammlungChange={onKombiSammlungChange}
+          onUpload={onKombiUpload}
+        />
+      </Box>
       </Box>
     </PageContainer>
   );


### PR DESCRIPTION
## Summary
- align buttons next to the dropdowns
- move description between selectors and adjust divider placement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685572c618f483208ba86bea786d779d