### PR TITLE
Show combination details

### DIFF
--- a/backend/frontend_config.py
+++ b/backend/frontend_config.py
@@ -16,7 +16,8 @@ def lade_frontend_konfiguration(kombis_df: pd.DataFrame) -> dict:
             "formel": row.get("formeltext", row.get("Formeltext", "")),
             "gewichtung": 3,  # Standardgewichtung "neutral"
             "aktiv": True,
-            "einheit": row.get("Einheit", ""),
+            # Some tables use "Result_Unit" instead of "Einheit"
+            "einheit": row.get("Einheit", row.get("Result_Unit", "")),
             # Manche Dateien nutzen "Direction" als Spaltenname
             "richtung": row.get("Richtung", row.get("Direction", "hoch"))
         }

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -156,21 +156,16 @@ export const WeightingSelector: React.FC<Props> = ({
                     <Box sx={{ p: 2 }}>
                       {(kombi.formel || kombi.einheit || kombi.richtung) && (
                         <Typography>
-                          {kombi.formel && (
-                            <>
-                              <b>{t('formula')}:</b>{' '}
-                              <span style={{ fontFamily: 'monospace' }}>{kombi.formel}</span>
-                              {kombi.einheit ? ` ${kombi.einheit}` : ''}
-                            </>
-                          )}
+                          {kombi.formel || ''}
+                          {kombi.einheit ? ` ${kombi.einheit}` : ''}
                           {kombi.richtung && (
-                            <>
-                              {' – '}
+                            <> {' '}
+                              {kombi.richtung}{' '}
                               {(() => {
                                 const dir = kombi.richtung.toLowerCase();
-                                if (['high', 'hoch'].includes(dir)) return t('higherIsBetter');
-                                if (['low', 'niedrig'].includes(dir)) return t('lowerIsBetter');
-                                return dir;
+                                if (['high', 'hoch'].includes(dir)) return `(${t('higherIsBetter')})`;
+                                if (['low', 'niedrig'].includes(dir)) return `(${t('lowerIsBetter')})`;
+                                return '';
                               })()}
                             </>
                           )}

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -70,8 +70,8 @@ const common = {
         explanation: "Erklärung",
         formula: "Formel",
         evaluationDirection: "Bewertungsrichtung",
-        higherIsBetter: "Höher ist besser",
-        lowerIsBetter: "Niedriger ist besser",
+        higherIsBetter: "Höheres Ergebnis besser",
+        lowerIsBetter: "Niedrigeres Ergebnis besser",
 
         thankYouForRating: "Danke für Ihre Bewertung!",
         evaluationId: "Bewertungs-ID",
@@ -281,8 +281,8 @@ const common = {
         explanation: "Explanation",
         formula: "Formula",
         evaluationDirection: "Evaluation direction",
-        higherIsBetter: "Higher is better",
-        lowerIsBetter: "Lower is better",
+        higherIsBetter: "Higher result better",
+        lowerIsBetter: "Lower result better",
 
         thankYouForRating: "Thank you for your rating!",
         evaluationId: "Evaluation ID",
@@ -492,8 +492,8 @@ const common = {
         explanation: "Explication",
         formula: "Formule",
         evaluationDirection: "Direction de l'évaluation",
-        higherIsBetter: "Plus élevé = mieux",
-        lowerIsBetter: "Plus bas = mieux",
+        higherIsBetter: "Résultat plus élevé = mieux",
+        lowerIsBetter: "Résultat plus bas = mieux",
 
         thankYouForRating: "Merci pour votre évaluation !",
         evaluationId: "ID d'évaluation",


### PR DESCRIPTION
## Summary
- show combination info text with unit and direction
- load Result_Unit column if available
- reword high/low translation strings

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68557aa5a10c8320b31aa365971e2a0f