### PR TITLE
Update ranking details formatting

### DIFF
--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -140,13 +140,13 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                       : t("higherIsBetter");
                                   const val =
                                     typeof wert === "number"
-                                      ? wert.toFixed(3)
+                                      ? Number(wert).toFixed(3)
                                       : wert;
                                   return (
                                     <TableRow key={kombi}>
                                       <TableCell>{info?.name || kombi}</TableCell>
                                       <TableCell>
-                                        {info?.formel ? `${info.formel}: ` : ""}
+                                        {info?.formel ? `${info.formel} ` : ""}
                                         {val}
                                         {info?.einheit ? ` ${info.einheit}` : ""}
                                         {info?.richtung && ` ${dirText}`}


### PR DESCRIPTION
## Summary
- show the text3 value before the result in ranking details
- round numeric result values to three decimals

## Testing
- `npm run lint` *(fails: Cannot find package due to missing dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557ad940508320abbe204fc8692be1