### PR TITLE
Fix footer layout

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -14,18 +14,22 @@ export const Footer: React.FC = () => {
   }, []);
 
   return (
-    <footer className="text-sm py-4 flex flex-col sm:flex-row items-center justify-center sm:justify-between">
-      <div className="flex items-center">
-        <p className="mb-2 sm:mb-0 sm:mr-2">{t('footerText')}</p>
-        <Link to="/impressum" className="text-blue-600 underline mr-2">
+    <footer className="w-full text-sm py-4">
+      <div
+        className="max-w-screen-lg mx-auto grid grid-cols-1 sm:grid-cols-3 gap-4 items-center text-center sm:text-left"
+      >
+        <p>
+          {t('footerText')} {new Date().getFullYear()}
+        </p>
+        <Link to="/impressum" className="text-blue-600 underline">
           {t('footerImpressum')}
         </Link>
+        {runCount !== null && (
+          <span className="text-xs text-gray-600 sm:text-right">
+            {t('calculationCounter', { count: runCount })}
+          </span>
+        )}
       </div>
-      {runCount !== null && (
-        <div className="mt-2 sm:mt-0 sm:ml-auto text-xs text-gray-600">
-          {t('calculationCounter', { count: runCount })}
-        </div>
-      )}
     </footer>
   );
 };


### PR DESCRIPTION
## Summary
- keep footer items on one line
- show current year after copyright symbol
- space footer items into three columns like the header

## Testing
- `./codex-setup.sh` *(fails: npm install requires internet)*

------
https://chatgpt.com/codex/tasks/task_e_68557b61843c8320ab9113e491437b88