### PR TITLE
Fix layout of SelectData page

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -148,7 +148,7 @@ return (
           ))}
         </Select>
       </FormControl>
-      <div className="flex flex-col space-y-2">
+      <div className="flex items-center space-x-2">
         <Button
           variant="contained"
           component="label"

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -149,7 +149,7 @@ return (
           ))}
         </Select>
       </FormControl>
-      <div className="flex flex-col space-y-2">
+      <div className="flex items-center space-x-2">
         <Button
           variant="contained"
           component="label"

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -59,25 +59,29 @@ export const SelectDataPage = ({
       </h2>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-<CollectionSelectorIdeas
-  aktuelleSammlungName={aktuelleIdeensammlung}
-  onSammlungChange={onIdeenSammlungChange}
-  onUpload={onIdeenUpload}
-/>
+        <Box mb={6}>
+          <CollectionSelectorIdeas
+            aktuelleSammlungName={aktuelleIdeensammlung}
+            onSammlungChange={onIdeenSammlungChange}
+            onUpload={onIdeenUpload}
+          />
+        </Box>
 
-<div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8 mt-8">
-  <p className="text-sm text-gray-700 text-center">
-    {t('selectDataInfo')}
-  </p>
-</div>
+        <Box mb={6}>
+          <CollectionSelectorKombis
+            aktuelleSammlungName={aktuelleKombiSammlung}
+            onSammlungChange={onKombiSammlungChange}
+            onUpload={onKombiUpload}
+          />
+        </Box>
 
-<Divider sx={{ my: 4, width: '100%' }} />
+        <Divider sx={{ my: 6, width: '100%' }} />
 
-<CollectionSelectorKombis
-  aktuelleSammlungName={aktuelleKombiSammlung}
-  onSammlungChange={onKombiSammlungChange}
-  onUpload={onKombiUpload}
-/>
+        <div className="bg-[#f8fafc] p-6 rounded-xl shadow mt-6">
+          <p className="text-sm text-gray-700 text-center">
+            {t('selectDataInfo')}
+          </p>
+        </div>
       </Box>
       </Box>
     </PageContainer>


### PR DESCRIPTION
## Summary
- align upload buttons horizontally next to dropdowns
- move info text below combination section with spacing
- adjust vertical spacing for better layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6855814143b08320a53a1bcac272cdcf