### PR TITLE
Implement session-based upload archiving

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,4 +1,13 @@
-from sqlalchemy import create_engine, Column, String, DateTime, JSON, Integer, Text
+from sqlalchemy import (
+    create_engine,
+    Column,
+    String,
+    DateTime,
+    JSON,
+    Integer,
+    Text,
+    Boolean,
+)
 from sqlalchemy.orm import declarative_base, sessionmaker
 from pathlib import Path
 import datetime
@@ -27,8 +36,17 @@ class UsageLog(Base):
     timestamp = Column(DateTime, default=datetime.datetime.utcnow)
     step = Column(String)
     data_json = Column(JSON)
-    ip = Column(String)
     user_agent = Column(Text)
+
+
+class UploadedFile(Base):
+    __tablename__ = "uploaded_files"
+    id = Column(Integer, primary_key=True, index=True)
+    session_id = Column(String, index=True)
+    sammlung_typ = Column(String)
+    filename = Column(String)
+    is_default = Column(Boolean, default=False)
+    timestamp = Column(DateTime, default=datetime.datetime.utcnow)
 
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ import json
 import uuid
 from datetime import datetime
 from config import config  # Deine eigene Configklasse!
-from database import init_db, SessionLocal, Calculation, UsageLog
+from database import init_db, SessionLocal, Calculation, UsageLog, UploadedFile
 from loader.excel_loader import ExcelLoader
 from validator.validate_ideen import validate_ideen_excel
 from validator.validate_kombis import validate_kombi_excel
@@ -124,6 +124,24 @@ async def upload_file(
     saved_file_path = save_path / file.filename
     with open(saved_file_path, "wb") as buffer:
         buffer.write(file_bytes)
+
+    # Datei auch im Archiv ablegen
+    session_archive = ARCHIVE_FOLDER / session / sammlung_typ
+    session_archive.mkdir(parents=True, exist_ok=True)
+    archive_file_path = session_archive / file.filename
+    with open(archive_file_path, "wb") as buffer:
+        buffer.write(file_bytes)
+
+    # in der Datenbank speichern
+    with SessionLocal() as db:
+        db_entry = UploadedFile(
+            session_id=session,
+            sammlung_typ=sammlung_typ,
+            filename=str(saved_file_path),
+            is_default=False,
+        )
+        db.add(db_entry)
+        db.commit()
 
     return {
         "message": t("upload_success", lang),
@@ -423,8 +441,7 @@ async def log_step(request: Request, payload: dict):
         "timestamp": datetime.utcnow().isoformat(),
         "step": step,
         "data": payload.get("data", {}),
-        "ip": request.client.host if request.client else None,
-        "user_agent": request.headers.get("User-Agent", "")
+        "user_agent": request.headers.get("User-Agent", ""),
     }
     # auch in die Datenbank schreiben
     with SessionLocal() as db:
@@ -433,12 +450,13 @@ async def log_step(request: Request, payload: dict):
             timestamp=datetime.utcnow(),
             step=step,
             data_json=payload.get("data", {}),
-            ip=request.client.host if request.client else None,
             user_agent=request.headers.get("User-Agent", ""),
         )
         db.add(log_row)
         db.commit()
-    log_file = ARCHIVE_FOLDER / f"{session}.jsonl"
+    session_folder = ARCHIVE_FOLDER / session
+    session_folder.mkdir(parents=True, exist_ok=True)
+    log_file = session_folder / "usage.jsonl"
     with open(log_file, "a", encoding="utf-8") as f:
         json.dump(entry, f, ensure_ascii=False)
         f.write("\n")


### PR DESCRIPTION
## Summary
- log user actions without IP address
- archive uploads per session and persist them in the database
- introduce `UploadedFile` model

## Testing
- `python -m py_compile backend/main.py backend/database.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855933351408320a5bbe743ad356e14