### PR TITLE
Make dropdown sections left-aligned

### DIFF
--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -128,9 +128,12 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
   };
 
 return (
-  <div className="max-w-xs">
-    <div className="flex items-start space-x-4">
-      <FormControl fullWidth size="small" sx={{ flexGrow: 1 }}>
+  <div>
+    <div
+      className="grid items-center"
+      style={{ gridTemplateColumns: '320px auto', columnGap: '1.5cm' }}
+    >
+      <FormControl size="small" sx={{ width: 320 }}>
         <InputLabel id="ideas-select-label">{t("selectCollection")}</InputLabel>
         <Select
           labelId="ideas-select-label"
@@ -148,12 +151,12 @@ return (
           ))}
         </Select>
       </FormControl>
-      <div className="flex flex-col space-y-2">
+      <div className="flex items-center space-x-4">
         <Button
           variant="contained"
           component="label"
           size="small"
-          sx={{ px: 1.5, py: 0.5 }}
+          sx={{ px: 1.5, py: 0.5, whiteSpace: 'nowrap' }}
         >
           {t("uploadFile")}
           <input
@@ -167,7 +170,7 @@ return (
         </Button>
         <Button
           variant="outlined"
-          sx={{ px: 1.5, py: 0.5 }}
+          sx={{ px: 1.5, py: 0.5, whiteSpace: 'nowrap' }}
           onClick={() =>
             window.open(`${backendUrl}/download_template?type=ideen`, '_blank')
           }

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -127,9 +127,12 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
   };
 
 return (
-  <div className="max-w-xs">
-    <div className="flex items-start space-x-4">
-      <FormControl fullWidth size="small" sx={{ flexGrow: 1 }}>
+  <div>
+    <div
+      className="grid items-center"
+      style={{ gridTemplateColumns: '320px auto', columnGap: '1.5cm' }}
+    >
+      <FormControl size="small" sx={{ width: 320 }}>
         <InputLabel id="kombis-select-label">
           {t("selectCombinationCollection")}
         </InputLabel>
@@ -149,12 +152,12 @@ return (
           ))}
         </Select>
       </FormControl>
-      <div className="flex flex-col space-y-2">
+      <div className="flex items-center space-x-4">
         <Button
           variant="contained"
           component="label"
           size="small"
-          sx={{ px: 1.5, py: 0.5 }}
+          sx={{ px: 1.5, py: 0.5, whiteSpace: 'nowrap' }}
         >
           {t("uploadFile")}
           <input
@@ -168,7 +171,7 @@ return (
         </Button>
         <Button
           variant="outlined"
-          sx={{ px: 1.5, py: 0.5 }}
+          sx={{ px: 1.5, py: 0.5, whiteSpace: 'nowrap' }}
           onClick={() =>
             window.open(`${backendUrl}/download_template?type=kombi`, '_blank')
           }
@@ -177,7 +180,7 @@ return (
           {t("downloadCombinationTemplate")}
         </Button>
       </div>
-    </div> {/* <-- DAS HAT GEFEHLT! */}
+    </div>
     {uploadError && (
       <pre className="text-red-600 mt-1 whitespace-pre-wrap">{uploadError}</pre>
     )}

--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -58,26 +58,30 @@ export const SelectDataPage = ({
         {t('masterDataSelectionTitle')}
       </h2>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-<CollectionSelectorIdeas
-  aktuelleSammlungName={aktuelleIdeensammlung}
-  onSammlungChange={onIdeenSammlungChange}
-  onUpload={onIdeenUpload}
-/>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', width: '100%' }}>
+        <Box mb={6} sx={{ width: '100%' }}>
+          <CollectionSelectorIdeas
+            aktuelleSammlungName={aktuelleIdeensammlung}
+            onSammlungChange={onIdeenSammlungChange}
+            onUpload={onIdeenUpload}
+          />
+        </Box>
 
-<div className="bg-[#f8fafc] p-6 rounded-xl shadow mb-8 mt-8">
-  <p className="text-sm text-gray-700 text-center">
-    {t('selectDataInfo')}
-  </p>
-</div>
+        <Box mb={6} sx={{ width: '100%' }}>
+          <CollectionSelectorKombis
+            aktuelleSammlungName={aktuelleKombiSammlung}
+            onSammlungChange={onKombiSammlungChange}
+            onUpload={onKombiUpload}
+          />
+        </Box>
 
-<Divider sx={{ my: 4, width: '100%' }} />
+        <Divider sx={{ my: 6, width: '100%' }} />
 
-<CollectionSelectorKombis
-  aktuelleSammlungName={aktuelleKombiSammlung}
-  onSammlungChange={onKombiSammlungChange}
-  onUpload={onKombiUpload}
-/>
+        <div className="bg-[#f8fafc] p-6 rounded-xl shadow mt-6">
+          <p className="text-sm text-gray-700 text-center">
+            {t('selectDataInfo')}
+          </p>
+        </div>
       </Box>
       </Box>
     </PageContainer>


### PR DESCRIPTION
## Summary
- adjust layout so dropdown sections align left
- widen spacing between action buttons
- ensure upload buttons start from the same position using a fixed select width
- vertically center dropdowns and buttons, leaving 1.5 cm space between them

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to environment limitations)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6855814143b08320a53a1bcac272cdcf