### PR TITLE
Add combination info table

### DIFF
--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -35,7 +35,7 @@ export const WeightingSelector: React.FC<Props> = ({
   kombinationen = [],
   onUpdate,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const gewichtungLabels = [
@@ -154,33 +154,52 @@ export const WeightingSelector: React.FC<Props> = ({
                 <TableCell colSpan={hasCategory ? 4 : 3} sx={{ p: 0 }}>
                   <Collapse in={expandedId === kombi.id} timeout="auto" unmountOnExit>
                     <Box sx={{ p: 2 }}>
-                      {(kombi.formel || kombi.einheit || kombi.richtung) && (
-                        <Typography>
-                          {kombi.formel && (
-                            <>
-                              {kombi.formel}
-                              <br />
-                            </>
-                          )}
-                          {kombi.einheit && (
-                            <>
-                              {kombi.einheit}
-                              <br />
-                            </>
-                          )}
-                          {kombi.richtung && (
-                            <>
-                              {kombi.richtung} –
-                              {(() => {
-                                const dir = kombi.richtung.toLowerCase();
-                                if (["high", "hoch"].includes(dir)) return ` ${t('higherIsBetter')}`;
-                                if (["low", "niedrig"].includes(dir)) return ` ${t('lowerIsBetter')}`;
-                                return "";
-                              })()}
-                            </>
-                          )}
-                        </Typography>
-                      )}
+                      {(() => {
+                        const formula =
+                          kombi[`#t_${i18n.language}#3`] || kombi.formel || "";
+                        const unit = kombi.einheit || kombi.Result_Unit || "";
+                        const direction = kombi.richtung || kombi.Direction || "";
+
+                        if (!formula && !unit && !direction) return null;
+
+                        const directionText = (() => {
+                          const dir = String(direction).toLowerCase();
+                          if (["high", "hoch"].includes(dir)) return t("higherIsBetter");
+                          if (["low", "niedrig"].includes(dir)) return t("lowerIsBetter");
+                          return "";
+                        })();
+
+                        return (
+                          <Table
+                            size="small"
+                            sx={{
+                              mt: 1,
+                              border: 1,
+                              borderColor: "divider",
+                              borderRadius: 1,
+                              '& td, & th': { borderColor: 'divider' },
+                            }}
+                          >
+                            <TableHead>
+                              <TableRow sx={{ bgcolor: "action.hover" }}>
+                                <TableCell>{t("formula")}</TableCell>
+                                <TableCell>{t("resultUnit")}</TableCell>
+                                <TableCell>{t("evaluationDirection")}</TableCell>
+                              </TableRow>
+                            </TableHead>
+                            <TableBody>
+                              <TableRow>
+                                <TableCell>{formula}</TableCell>
+                                <TableCell>{unit}</TableCell>
+                                <TableCell>
+                                  {direction}
+                                  {directionText && ` – ${directionText}`}
+                                </TableCell>
+                              </TableRow>
+                            </TableBody>
+                          </Table>
+                        );
+                      })()}
                     </Box>
                   </Collapse>
                 </TableCell>

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -69,6 +69,7 @@ const common = {
 
         explanation: "Erklärung",
         formula: "Formel",
+        resultUnit: "Ergebniseinheit",
         evaluationDirection: "Bewertungsrichtung",
         higherIsBetter: "Höheres Ergebnis ist besser",
         lowerIsBetter: "Niedrigeres Ergebnis ist besser",
@@ -280,6 +281,7 @@ const common = {
 
         explanation: "Explanation",
         formula: "Formula",
+        resultUnit: "Result unit",
         evaluationDirection: "Evaluation direction",
         higherIsBetter: "Higher result is better",
         lowerIsBetter: "Lower result is better",
@@ -491,6 +493,7 @@ const common = {
 
         explanation: "Explication",
         formula: "Formule",
+        resultUnit: "Unité du résultat",
         evaluationDirection: "Direction de l'évaluation",
         higherIsBetter: "Résultat plus élevé est meilleur",
         lowerIsBetter: "Résultat plus bas est meilleur",


### PR DESCRIPTION
## Summary
- show info for each combination in a small table
- add translations for `resultUnit`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68559766159083208f3c5582f40422b0