### PR TITLE
Add formula and unit columns to result table

### DIFF
--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -125,7 +125,9 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                             <TableHead>
                               <TableRow>
                                 <TableCell>{t("combination")}</TableCell>
-                                <TableCell>{t("value")}</TableCell>
+                                <TableCell>{t("formula")}</TableCell>
+                                <TableCell align="right">{t("value")}</TableCell>
+                                <TableCell>{t("resultUnit")}</TableCell>
                               </TableRow>
                             </TableHead>
                             <TableBody>
@@ -133,11 +135,6 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                 Object.entries(eintrag.details).map(([kombi, wert]) => {
                                   const id = kombi.replace(/^Kombi_/, "");
                                   const info = kombinationen?.find(k => String(k.id) === id);
-                                  const richtung = info?.richtung?.toLowerCase() || "";
-                                  const dirText =
-                                    richtung === "low"
-                                      ? t("lowerIsBetter")
-                                      : t("higherIsBetter");
                                   const val =
                                     typeof wert === "number"
                                       ? Number(wert).toFixed(3)
@@ -145,18 +142,15 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                   return (
                                     <TableRow key={kombi}>
                                       <TableCell>{info?.name || kombi}</TableCell>
-                                      <TableCell>
-                                        {info?.formel ? `${info.formel} ` : ""}
-                                        {val}
-                                        {info?.einheit ? ` ${info.einheit}` : ""}
-                                        {info?.richtung && ` ${dirText}`}
-                                      </TableCell>
+                                      <TableCell>{info?.formel || ""}</TableCell>
+                                      <TableCell align="right">{val}</TableCell>
+                                      <TableCell>{info?.einheit || ""}</TableCell>
                                     </TableRow>
                                   );
                                 })
                               ) : (
                                 <TableRow>
-                                  <TableCell colSpan={2}>
+                                  <TableCell colSpan={4}>
                                     <Typography color="text.secondary">{t("noDetails")}</Typography>
                                   </TableCell>
                                 </TableRow>

--- a/frontend/src/i18n/common.ts
+++ b/frontend/src/i18n/common.ts
@@ -69,6 +69,7 @@ const common = {
 
         explanation: "Erklärung",
         formula: "Formel",
+        resultUnit: "Ergebniseinheit",
         evaluationDirection: "Bewertungsrichtung",
         higherIsBetter: "Höheres Ergebnis ist besser",
         lowerIsBetter: "Niedrigeres Ergebnis ist besser",
@@ -280,6 +281,7 @@ const common = {
 
         explanation: "Explanation",
         formula: "Formula",
+        resultUnit: "Result unit",
         evaluationDirection: "Evaluation direction",
         higherIsBetter: "Higher result is better",
         lowerIsBetter: "Lower result is better",
@@ -491,6 +493,7 @@ const common = {
 
         explanation: "Explication",
         formula: "Formule",
+        resultUnit: "Unité du résultat",
         evaluationDirection: "Direction de l'évaluation",
         higherIsBetter: "Résultat plus élevé est meilleur",
         lowerIsBetter: "Résultat plus bas est meilleur",


### PR DESCRIPTION
## Summary
- show formula and result unit in the results detail table
- right-align value column
- update i18n for new `resultUnit` label

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68559b90e5f483209fbff9a8d0c344b5