### PR TITLE
Fix formula display on results page

### DIFF
--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -35,7 +35,7 @@ type Props = {
 };
 
 export const Ranking = ({ eintraege, kombinationen }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [infoId, setInfoId] = useState<string | null>(null);
   const [detailIds, setDetailIds] = useState<string[]>([]);
 
@@ -142,7 +142,10 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                   return (
                                     <TableRow key={kombi}>
                                       <TableCell>{info?.name || kombi}</TableCell>
-                                      <TableCell>{info?.formel || ""}</TableCell>
+                                      <TableCell>
+                                        {info?.formel ||
+                                          info?.[`#t_${i18n.language}#3`] || ""}
+                                      </TableCell>
                                       <TableCell align="right">{val}</TableCell>
                                       <TableCell>{info?.einheit || ""}</TableCell>
                                     </TableRow>


### PR DESCRIPTION
## Summary
- use i18n instance in `Ranking` component
- show language-specific formula text in results table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68559f1074388320a4ad596572f7e19e