### PR TITLE
Improve results toggle clarity

### DIFF
--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -80,8 +80,12 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                   </TableCell>
                   <TableCell align="center">
                     {eintrag.beschreibung && (
-                      <Button size="small" onClick={() => setInfoId(showInfo ? null : eintrag.id)}>
-                        {t("info")}
+                      <Button
+                        size="small"
+                        variant={showInfo ? "contained" : "outlined"}
+                        onClick={() => setInfoId(showInfo ? null : eintrag.id)}
+                      >
+                        {showInfo ? t("close") : t("info")}
                       </Button>
                     )}
                   </TableCell>
@@ -89,6 +93,7 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                     {eintrag.details && (
                       <Button
                         size="small"
+                        variant={showDetails ? "contained" : "outlined"}
                         onClick={() =>
                           setDetailIds((prev) =>
                             prev.includes(eintrag.id)
@@ -97,7 +102,7 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                           )
                         }
                       >
-                        {t("details")}
+                        {showDetails ? t("close") : t("details")}
                       </Button>
                     )}
                   </TableCell>


### PR DESCRIPTION
## Summary
- highlight when info or details are open in the ranking table

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6855a0fe719883208421b3994856cc96