### PR TITLE
Style description field as block text

### DIFF
--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -79,8 +79,10 @@ export const SelectDataPage = ({
 
 
         <div className="bg-[#f8fafc] p-6 rounded-xl shadow mt-6 flex items-center justify-center">
-          <p className="text-sm text-gray-700 w-full" style={{ textAlign: 'justify' }}>
-
+          <p
+            className="text-sm text-gray-700 w-full"
+            style={{ textAlign: 'justify', whiteSpace: 'pre-line' }}
+          >
             {t('selectDataInfo')}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- preserve newlines in the SelectData info text so multi-line descriptions display nicely

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6855a124e7d8832099cb21303da0d823