### PR TITLE
Fix formula info display in results table

### DIFF
--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -134,7 +134,7 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                               {Object.entries(eintrag.details).length > 0 ? (
                                 Object.entries(eintrag.details).map(([kombi, wert]) => {
                                   const id = kombi.replace(/^Kombi_/, "");
-                                  const info = kombinationen?.find(k => String(k.id) === id);
+                                  const info = kombinationen?.find((k) => String(k.id) === id);
                                   const val =
                                     typeof wert === "number"
                                       ? Number(wert).toFixed(3)
@@ -144,10 +144,12 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                       <TableCell>{info?.name || kombi}</TableCell>
                                       <TableCell>
                                         {info?.formel ||
-                                          info?.[`#t_${i18n.language}#3`] || ""}
+                                          info?.[`#t_${i18n.language.slice(0, 2)}#3`] || ""}
                                       </TableCell>
                                       <TableCell align="right">{val}</TableCell>
-                                      <TableCell>{info?.einheit || ""}</TableCell>
+                                      <TableCell>
+                                        {info?.einheit || info?.Result_Unit || ""}
+                                      </TableCell>
                                     </TableRow>
                                   );
                                 })


### PR DESCRIPTION
## Summary
- fix language-specific formula lookup
- show result unit for combinations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a1fd118c83208bb763a77b057dfd