### PR TITLE
Fix dynamic language switch for results

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -369,6 +369,33 @@ function App() {
 
   // Entfernt: useEffect mit setSaveRunSuccessOpen
 
+  // Recalculate ranking results when language changes
+  useEffect(() => {
+    if (rankingEintraege.length === 0) return;
+    const gew: Record<string, number> = {};
+    gewichtungen.forEach((k: any) => {
+      gew[k.id] = Number(k.gewichtung || 0);
+    });
+    calculateRanking({
+      session: sessionId,
+      ideen_file: aktuelleIdeensammlung,
+      kombi_file: aktuelleKombiSammlung,
+      ideen_ids: ideen.filter((i) => i.aktiv).map((i) => i.id),
+      gewichtungen: gew,
+      lang: language,
+    })
+      .then(setRankingEintraege)
+      .catch((err) => {
+        console.error(err);
+        setStatusToastMessage(
+          `${t('loadError')}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        setStatusToastType('error');
+        setStatusToastOpen(true);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [language]);
+
   useEffect(() => {
     loadIdeen(aktuelleIdeensammlung);
     loadKombis(aktuelleKombiSammlung);


### PR DESCRIPTION
## Summary
- recalc ranking results when changing language

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a26482188320b01f85c643cd4407