### PR TITLE
Fix formula info display in results table

### DIFF
--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -134,7 +134,7 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                               {Object.entries(eintrag.details).length > 0 ? (
                                 Object.entries(eintrag.details).map(([kombi, wert]) => {
                                   const id = kombi.replace(/^Kombi_/, "");
-                                  const info = kombinationen?.find(k => String(k.id) === id);
+                                  const info = kombinationen?.find((k) => String(k.id) === id);
                                   const val =
                                     typeof wert === "number"
                                       ? Number(wert).toFixed(3)
@@ -143,11 +143,13 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                     <TableRow key={kombi}>
                                       <TableCell>{info?.name || kombi}</TableCell>
                                       <TableCell>
-                                        {info?.formel ||
-                                          info?.[`#t_${i18n.language}#3`] || ""}
+                                        {info?.[`#t_${i18n.language.slice(0, 2)}#3`] ||
+                                          info?.formel || ""}
                                       </TableCell>
                                       <TableCell align="right">{val}</TableCell>
-                                      <TableCell>{info?.einheit || ""}</TableCell>
+                                      <TableCell>
+                                        {info?.einheit || info?.Result_Unit || ""}
+                                      </TableCell>
                                     </TableRow>
                                   );
                                 })

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -203,19 +203,8 @@ export const WeightingSelector: React.FC<Props> = ({
                 </TableRow>
               </TableBody>
             </Table>
-            {description && (
-              <Typography sx={{ mt: 1 }}>{description}</Typography>
-            )}
+            {/* description intentionally not shown below the table */}
           </>
-        );
-      }
-
-      // Wenn nur Beschreibung da ist (und nichts anderes)
-      if (description) {
-        return (
-          <Typography>
-            {description}
-          </Typography>
         );
       }
 


### PR DESCRIPTION
## Summary
- stop showing formula text underneath weighting table
- look up formula text before raw formula in ranking table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a1fd118c83208bb763a77b057dfd