### PR TITLE
Fix dynamic formula language

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -369,6 +369,33 @@ function App() {
 
   // Entfernt: useEffect mit setSaveRunSuccessOpen
 
+  // Recalculate ranking results when language changes
+  useEffect(() => {
+    if (rankingEintraege.length === 0) return;
+    const gew: Record<string, number> = {};
+    gewichtungen.forEach((k: any) => {
+      gew[k.id] = Number(k.gewichtung || 0);
+    });
+    calculateRanking({
+      session: sessionId,
+      ideen_file: aktuelleIdeensammlung,
+      kombi_file: aktuelleKombiSammlung,
+      ideen_ids: ideen.filter((i) => i.aktiv).map((i) => i.id),
+      gewichtungen: gew,
+      lang: language,
+    })
+      .then(setRankingEintraege)
+      .catch((err) => {
+        console.error(err);
+        setStatusToastMessage(
+          `${t('loadError')}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        setStatusToastType('error');
+        setStatusToastOpen(true);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [language]);
+
   useEffect(() => {
     loadIdeen(aktuelleIdeensammlung);
     loadKombis(aktuelleKombiSammlung);

--- a/frontend/src/components/Ranking.tsx
+++ b/frontend/src/components/Ranking.tsx
@@ -143,8 +143,11 @@ export const Ranking = ({ eintraege, kombinationen }: Props) => {
                                     <TableRow key={kombi}>
                                       <TableCell>{info?.name || kombi}</TableCell>
                                       <TableCell>
-                                        {info?.formel ||
-                                          info?.[`#t_${i18n.language}#3`] || ""}
+                                        {(() => {
+                                          const langKey = i18n.language.slice(0, 2);
+                                          const byLang = info?.[`#t_${langKey}#3`];
+                                          return byLang || info?.formel || "";
+                                        })()}
                                       </TableCell>
                                       <TableCell align="right">{val}</TableCell>
                                       <TableCell>{info?.einheit || ""}</TableCell>

--- a/frontend/src/components/WeightingSelector.tsx
+++ b/frontend/src/components/WeightingSelector.tsx
@@ -156,9 +156,12 @@ export const WeightingSelector: React.FC<Props> = ({
   <Box sx={{ p: 2 }}>
     {(() => {
       // Korrigierte Deklaration:
-      const formula = kombi.formel || "";
       const langKey = i18n.language.slice(0, 2);
-      const description = kombi[`#t_${langKey}#3`] || "";
+      const formula =
+        kombi[`#t_${langKey}#3`] ||
+        kombi.formel ||
+        "";
+      const description = kombi[`#t_${langKey}#3`] || kombi.beschreibung || "";
       const unit = kombi.einheit || kombi.Result_Unit || "";
       const direction = kombi.richtung || kombi.Direction || "";
 


### PR DESCRIPTION
## Summary
- respect current language when rendering formula text in results
- adjust WeightingSelector to use translated formula info

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a26482188320b01f85c643cd4407