### PR TITLE
Fix config file path

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -3,10 +3,23 @@ import os
 from pathlib import Path
 
 class Config:
-    def __init__(self, filepath="matrixconfig.ini"):
+    def __init__(self, filepath=None):
+        """Load configuration from ``matrixconfig.ini``.
+
+        If ``filepath`` is not provided, the config file is expected next to this
+        module. This ensures the file is found regardless of the current working
+        directory when the backend is started.
+        """
+        if filepath is None:
+            filepath = Path(__file__).parent / "matrixconfig.ini"
+        else:
+            filepath = Path(filepath)
+
         self.config = configparser.ConfigParser()
-        if not os.path.exists(filepath):
-            raise FileNotFoundError(f"Konfigurationsdatei {filepath} nicht gefunden.")
+        if not filepath.exists():
+            raise FileNotFoundError(
+                f"Konfigurationsdatei {filepath} nicht gefunden."
+            )
         self.config.read(filepath)
         self._validate()
 


### PR DESCRIPTION
## Summary
- load `matrixconfig.ini` from the backend directory by default
- add documentation to Config constructor

## Testing
- `./codex-setup.sh` *(fails: network disabled)*
- `pytest -q`
- `npm run lint` *(fails: missing package globals)*

------
https://chatgpt.com/codex/tasks/task_e_6855b1cb40d08320aeba0e76b1f5b031