### PR TITLE
Allow configuring dev2 checkbox

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -3,10 +3,23 @@ import os
 from pathlib import Path
 
 class Config:
-    def __init__(self, filepath="matrixconfig.ini"):
+    def __init__(self, filepath=None):
+        """Load configuration from ``matrixconfig.ini``.
+
+        If ``filepath`` is not provided, the config file is expected next to this
+        module. This ensures the file is found regardless of the current working
+        directory when the backend is started.
+        """
+        if filepath is None:
+            filepath = Path(__file__).parent / "matrixconfig.ini"
+        else:
+            filepath = Path(filepath)
+
         self.config = configparser.ConfigParser()
-        if not os.path.exists(filepath):
-            raise FileNotFoundError(f"Konfigurationsdatei {filepath} nicht gefunden.")
+        if not filepath.exists():
+            raise FileNotFoundError(
+                f"Konfigurationsdatei {filepath} nicht gefunden."
+            )
         self.config.read(filepath)
         self._validate()
 
@@ -134,6 +147,10 @@ class Config:
     @property
     def show_tester_checkbox(self):
         return self.testerbutton_enabled
+
+    @property
+    def show_dev2_checkbox(self):
+        return self._feature("dev2_checkbox")
 
     @property
     def log_level(self):

--- a/backend/main.py
+++ b/backend/main.py
@@ -269,6 +269,7 @@ async def get_features():
     return {
         "show_round_options": config.show_round_options,
         "show_tester_checkbox": config.show_tester_checkbox,
+        "show_dev2_checkbox": config.show_dev2_checkbox,
         "loadingscreen_duration": config.duration_loadingscreen,
     }
 

--- a/backend/matrixconfig.ini
+++ b/backend/matrixconfig.ini
@@ -24,6 +24,7 @@ valid_kombi_template = uploads/selectioncombis/standard_kombi.xlsx
 
 [Features]
 dev_mode_button = false
+dev2_checkbox = off
 datapopup = on
 testerbutton = on
 enable_export_pdf = true

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,6 +52,7 @@ function App() {
   const [datenfreigabe, setDatenfreigabe] = useState<"offen" | "anonym" | "keine">("offen");
   const [showRoundOptions, setShowRoundOptions] = useState(true);
   const [showTesterOption, setShowTesterOption] = useState(true);
+  const [showDev2Option, setShowDev2Option] = useState(false);
   const [loadingScreenDuration, setLoadingScreenDuration] = useState(0.8);
   const [gewichtungen, setGewichtungen] = useState<any[]>([]);
   const [rankingEintraege, setRankingEintraege] = useState<any[]>([]);
@@ -80,6 +81,13 @@ function App() {
         }
         if (typeof data.show_tester_checkbox === "boolean") {
           setShowTesterOption(data.show_tester_checkbox);
+        }
+        if (typeof data.show_dev2_checkbox === "boolean") {
+          setShowDev2Option(data.show_dev2_checkbox);
+          if (!data.show_dev2_checkbox) {
+            setDev2Mode(false);
+            sessionStorage.setItem('dev2mode', 'false');
+          }
         }
         if (typeof data.loadingscreen_duration === "number") {
           setLoadingScreenDuration(data.loadingscreen_duration);
@@ -420,7 +428,7 @@ function App() {
       >
         Session ID: {sessionId}
       </Typography>
-      {location.pathname === '/' && devConfig.dataSaveStatus === 'on' && (
+      {location.pathname === '/' && showDev2Option && (
         <FormControlLabel
           control={
             <Checkbox
@@ -483,7 +491,7 @@ function App() {
 </AppBar>
 
 
-      {dev2Mode && devConfig.dataSaveStatus === 'on' && <DevStatusBar />}
+      {dev2Mode && showDev2Option && devConfig.dataSaveStatus === 'on' && <DevStatusBar />}
 
       <Container sx={{ flexGrow: 1, bgcolor: 'background.paper', py: 2 }} maxWidth="lg">
         <Routes>

--- a/frontend/src/components/CollectionSelectorIdeas.tsx
+++ b/frontend/src/components/CollectionSelectorIdeas.tsx
@@ -50,11 +50,12 @@ export const CollectionSelectorIdeas: React.FC<Props> = ({
       .then((data) => {
         if (data.files && data.files.length > 0) {
           setEigeneSammlungen(data.files);
-          if (!data.files.includes(auswahl)) {
-            const neueAuswahl = data.default || data.files[0];
-            setAuswahl(neueAuswahl);
-            onSammlungChange(neueAuswahl);
-          }
+          const neueAuswahl =
+            data.default && data.files.includes(data.default)
+              ? data.default
+              : data.files[0];
+          setAuswahl(neueAuswahl);
+          onSammlungChange(neueAuswahl);
         }
       })
       .catch((err) => {

--- a/frontend/src/components/CollectionSelectorKombis.tsx
+++ b/frontend/src/components/CollectionSelectorKombis.tsx
@@ -50,11 +50,12 @@ export const CollectionSelectorKombis: React.FC<Props> = ({
       .then((data) => {
         if (data.files && data.files.length > 0) {
           setEigeneSammlungen(data.files);
-          if (!data.files.includes(auswahl)) {
-            const neueAuswahl = data.default || data.files[0];
-            setAuswahl(neueAuswahl);
-            onSammlungChange(neueAuswahl);
-          }
+          const neueAuswahl =
+            data.default && data.files.includes(data.default)
+              ? data.default
+              : data.files[0];
+          setAuswahl(neueAuswahl);
+          onSammlungChange(neueAuswahl);
         }
       })
       .catch((err) => {


### PR DESCRIPTION
## Summary
- add `show_dev2_checkbox` to API features
- read new `dev2_checkbox` flag from `matrixconfig.ini`
- show dev2 checkbox only when backend flag is on
- fix default file selection to always use backend defaults

## Testing
- `./codex-setup.sh` *(fails: network disabled)*
- `pytest -q`
- `npm run lint` *(fails: missing package)*

------
https://chatgpt.com/codex/tasks/task_e_6855b1cb40d08320aeba0e76b1f5b031