### PR TITLE
Center info box on SelectDataPage

### DIFF
--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -78,9 +78,9 @@ export const SelectDataPage = ({
         <Divider sx={{ my: 6, width: '100%' }} />
 
 
-        <div className="bg-[#f8fafc] p-6 rounded-xl shadow mt-6 flex items-center justify-center">
+        <div className="bg-[#f8fafc] p-6 rounded-xl shadow mt-6 flex items-center justify-center max-w-prose mx-auto">
 
-          <p className="text-sm text-gray-700 w-full" style={{ textAlign: 'center' }}>
+          <p className="text-sm text-gray-700" style={{ textAlign: 'center' }}>
             {t('selectDataInfo')}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- horizontally center info text on select data page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6855b77d486c8320ad647ee35f3f7061