### PR TITLE
Fix CORS origins list

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ valid_kombi_template = Path(config.valid_kombi_template).resolve()
 origins = [
     "https://reliable-pudding-2fdba3.netlify.app",
     "https://matrix.gruppe4-projektentwicklung.de",
-    "https://matrix-v1-backend.onrender.com"
+    "https://matrix-v1-backend.onrender.com",
     "http://localhost:3000",
     "http://localhost:5173",
 ]


### PR DESCRIPTION
## Summary
- add missing comma in CORS origins list so separate origins don't get concatenated

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6859c0a933808320afb31e10bd4210f3