### PR TITLE
Fix select data instructions rendering

### DIFF
--- a/frontend/src/pages/SelectDataPage.tsx
+++ b/frontend/src/pages/SelectDataPage.tsx
@@ -97,12 +97,11 @@ export const SelectDataPage = ({
             {t('downloadInstructions')}
           </Button>
 
-          <p className="text-sm text-gray-700" style={{ textAlign: 'center' }}>
-            {t('selectDataInfo')}
-          </p>
-          <Button variant="outlined" sx={{ mt: 2 }} onClick={handleInstructionDownload} size="small">
-            {t('downloadInstructions')}
-          </Button>
+          <p
+            className="text-sm text-gray-700"
+            style={{ textAlign: 'center' }}
+            dangerouslySetInnerHTML={{ __html: t('selectDataInfo') }}
+          />
         </div>
       </Box>
       </Box>


### PR DESCRIPTION
## Summary
- render HTML for `selectDataInfo` using `dangerouslySetInnerHTML`
- remove duplicate download button on SelectDataPage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6859c43876e883208eb0abaa8b417ce8