### PR TITLE
Fix combination page text alignment

### DIFF
--- a/frontend/src/pages/CombinationSelectionPage.tsx
+++ b/frontend/src/pages/CombinationSelectionPage.tsx
@@ -78,7 +78,7 @@ export const CombinationSelectionPage = ({
         />
         <Typography
           mt={2}
-          textAlign="center"
+          textAlign="left"
           color="text.secondary"
           component="div"
           dangerouslySetInnerHTML={{ __html: t('selectWeightsInfo') }}


### PR DESCRIPTION
## Summary
- keep combination info text left-aligned so bullet lists look normal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859d02f2b808320b28a1158b51fb25e