### PR TITLE
Fix default ideas file

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
 
   // Default file names should mirror the backend configuration
   // (see backend/matrixconfig.ini -> default_ideen / default_kombi)
-  const [aktuelleIdeensammlung, setAktuelleIdeensammlung] = useState("standard_ideen.xlsx");
+  const [aktuelleIdeensammlung, setAktuelleIdeensammlung] = useState("CW26_idea_list.xlsx");
   const [aktuelleKombiSammlung, setAktuelleKombiSammlung] = useState("CW25_combi_list.xlsx");
 
   // Backend-Feature-Flags laden


### PR DESCRIPTION
## Summary
- fix default idea file name in the frontend so it matches `backend/matrixconfig.ini`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a6bdba24483208eb7d3c4832b75fb